### PR TITLE
Support login from Data Kitchen

### DIFF
--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -591,6 +591,7 @@ export function renderSignInPopup (dom: HTMLDocument) {
       border-radius: 4px;
       min-width: 400px;
       padding: 10px;
+      z-index : 10;
     `
   )
   issuerPopup.appendChild(issuerPopupBox)

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -785,7 +785,20 @@ export function loginStatusBox (
   }
 
   box.refresh = function () {
-    me = authn.authSession.info.webId;
+    const sessionInfo = authSession.info
+    if (sessionInfo && sessionInfo.webId && sessionInfo.isLoggedIn) {
+      me = sym(sessionInfo.webId)
+    } else {
+      me = null
+    }
+    if ((me && box.me !== me.uri) || (!me && box.me)) {
+      widgets.clearElement(box)
+      if (me) {
+        box.appendChild(logoutButton(me, options))
+      } else {
+        box.appendChild(signInOrSignUpBox(dom, setIt, options))
+      }
+    }
     if ((me && box.me !== me.uri) || (!me && box.me)) {
       widgets.clearElement(box)
       if (me) {

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -787,7 +787,7 @@ export function loginStatusBox (
   box.refresh = function () {
     const sessionInfo = authSession.info
     if (sessionInfo && sessionInfo.webId && sessionInfo.isLoggedIn) {
-      me = sym(sessionInfo.webId)
+      me = solidLogicSingleton.store.sym(sessionInfo.webId)
     } else {
       me = null
     }

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -784,7 +784,7 @@ export function loginStatusBox (
   }
 
   box.refresh = function () {
-    me = _solidLogic.authn.authSession.info.webId;
+    me = authn.authSession.info.webId;
     if ((me && box.me !== me.uri) || (!me && box.me)) {
       widgets.clearElement(box)
       if (me) {

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -784,7 +784,7 @@ export function loginStatusBox (
   }
 
   box.refresh = function () {
-    me = authn.currentUser()
+    me = _solidLogic.authn.authSession.info.webId;
     if ((me && box.me !== me.uri) || (!me && box.me)) {
       widgets.clearElement(box)
       if (me) {

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -799,14 +799,6 @@ export function loginStatusBox (
         box.appendChild(signInOrSignUpBox(dom, setIt, options))
       }
     }
-    if ((me && box.me !== me.uri) || (!me && box.me)) {
-      widgets.clearElement(box)
-      if (me) {
-        box.appendChild(logoutButton(me, options))
-      } else {
-        box.appendChild(signInOrSignUpBox(dom, setIt, options))
-      }
-    }
     box.me = me ? me.uri : null
   }
   box.refresh()


### PR DESCRIPTION
The box.refresh method is one place where we can NOT use authn.currentUser() because what we want to know is not just is the user authorized to be here but are they actually logged in.  So we need authn.authSession.info here.  Otherwise when we are in Data-Kitchen we appear to be logged in to the local host  (so we can access it all) but we aren't actually logged in to it.  However we want the option to login to other places so box.refresh needs to check whether we are actually logged in somewhere else and if not give us the issuer popup.