### PR TITLE
checked login status

### DIFF
--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -1055,7 +1055,7 @@ export async function getUserRoles (): Promise<Array<NamedNode>> {
   try {
     const { me, preferencesFile, preferencesFileError } = await ensureLoadedPreferences({ me: currentUser })
     if (!preferencesFile || preferencesFileError) {
-      return []
+      throw new Error(preferencesFileError)
     }
     return solidLogicSingleton.store.each(
       me,

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -1047,10 +1047,15 @@ export function newAppInstance (
  * and/or a developer
  */
 export async function getUserRoles (): Promise<Array<NamedNode>> {
+  const currentUser = authn.currentUser()
+  if (!currentUser) {
+    return []
+  }
+
   try {
-    const { me, preferencesFile, preferencesFileError } = await ensureLoadedPreferences({})
+    const { me, preferencesFile, preferencesFileError } = await ensureLoadedPreferences({ me: currentUser })
     if (!preferencesFile || preferencesFileError) {
-      throw new Error(preferencesFileError)
+      return []
     }
     return solidLogicSingleton.store.each(
       me,

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -1055,7 +1055,7 @@ export async function getUserRoles (): Promise<Array<NamedNode>> {
   try {
     const { me, preferencesFile, preferencesFileError } = await ensureLoadedPreferences({ me: currentUser })
     if (!preferencesFile || preferencesFileError) {
-      throw new Error(preferencesFileError)
+      throw new Error(preferencesFileError || 'Unable to load user preferences file.')
     }
     return solidLogicSingleton.store.each(
       me,

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -1047,6 +1047,11 @@ export function newAppInstance (
  * and/or a developer
  */
 export async function getUserRoles (): Promise<Array<NamedNode>> {
+   const sessionInfo = authSession.info
+  if (!sessionInfo?.isLoggedIn || !sessionInfo?.webId) {
+    return []
+  }
+  
   const currentUser = authn.currentUser()
   if (!currentUser) {
     return []

--- a/test/unit/login/login.test.ts
+++ b/test/unit/login/login.test.ts
@@ -11,3 +11,29 @@ describe('ensureLoggedIn', () => {
     expect(testLogin.ensureLoggedIn({})).toBeInstanceOf(Object)
   })
 })
+
+describe('getUserRoles', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.resetModules()
+  })
+
+  it('returns [] and does not load preferences when current user is missing', async () => {
+    const solidLogic = require('solid-logic')
+
+    const currentUserSpy = jest
+      .spyOn(solidLogic.authn, 'currentUser')
+      .mockReturnValue(null)
+    const loadPreferencesSpy = jest.spyOn(
+      solidLogic.solidLogicSingleton.profile,
+      'loadPreferences'
+    )
+
+    const loginModule = require('../../../src/login/login')
+    const roles = await loginModule.getUserRoles()
+
+    expect(currentUserSpy).toHaveBeenCalled()
+    expect(roles).toEqual([])
+    expect(loadPreferencesSpy).not.toHaveBeenCalled()
+  })
+})

--- a/test/unit/login/login.test.ts
+++ b/test/unit/login/login.test.ts
@@ -21,6 +21,11 @@ describe('getUserRoles', () => {
   it('returns [] and does not load preferences when current user is missing', async () => {
     const solidLogic = require('solid-logic')
 
+    solidLogic.authSession.info = {
+      isLoggedIn: true,
+      webId: 'https://alice.example.com/profile/card#me'
+    }
+
     const currentUserSpy = jest
       .spyOn(solidLogic.authn, 'currentUser')
       .mockReturnValue(null)


### PR DESCRIPTION
Ticket https://github.com/SolidOS/solid-ui/issues/464 

This PR resolves the error that comes up in the console when the user logs out and the browser reloads it still tries to get the User Roles which tries to load the preferences. When a user isn't logged in it should just return and not load preferences.

i was able to test this in SolidOS local.