### PR TITLE
Resolve race conditions for loadPreferences

### DIFF
--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -449,29 +449,50 @@ function signInOrSignUpBox (
       // destructive clears or forced navigation that can hide existing entries.
       try {
         const storageRoot = store.any(me, ns.space('storage')) as NamedNode | null
-        if (storageRoot) {
-          await store.fetcher.load(storageRoot, { force: true })
+        const resourcesToReload: NamedNode[] = []
+        const seenResources = new Set<string>()
+        const queueResource = (resource: NamedNode | null | undefined): void => {
+          if (!resource || seenResources.has(resource.uri)) return
+          seenResources.add(resource.uri)
+          resourcesToReload.push(resource)
         }
 
+        queueResource(me.doc())
+        queueResource(storageRoot)
         if (preferencesFile) {
-          const settingsContainer = preferencesFile.doc().dir()
-          if (settingsContainer) {
-            await store.fetcher.load(settingsContainer, { force: true })
+          const preferencesDoc = preferencesFile.doc()
+          const settingsContainer = preferencesDoc.dir()
+          queueResource(preferencesDoc)
+          queueResource(settingsContainer)
 
-            // Some servers or cached container states may omit settings from
-            // the visible root listing even when the container exists.
-            // Ensure folder UIs can discover it from local store state.
-            if (storageRoot &&
-              !store.holds(storageRoot, ns.ldp('contains'), settingsContainer, storageRoot.doc())) {
-              store.add(storageRoot, ns.ldp('contains'), settingsContainer, storageRoot.doc())
+          // If settings are under the advertised storage root, proactively load
+          // each ancestor container so folder UIs can discover the path via
+          // fetched containment data rather than synthesized triples.
+          if (storageRoot && settingsContainer) {
+            const normalizedRoot = storageRoot.uri.endsWith('/') ? storageRoot.uri : `${storageRoot.uri}/`
+            if (settingsContainer.uri.startsWith(normalizedRoot)) {
+              const relativeParts = settingsContainer.uri
+                .slice(normalizedRoot.length)
+                .split('/')
+                .filter(Boolean)
+              let cursor = normalizedRoot
+              for (const part of relativeParts) {
+                cursor += `${part}/`
+                queueResource(store.sym(cursor))
+              }
             }
           }
+
         }
 
         const currentUri = (dom.getElementById('UserURI') as HTMLInputElement | null)?.value
         if (currentUri) {
-          await store.fetcher.load(store.sym(currentUri), { force: true })
+          queueResource(store.sym(currentUri))
         }
+
+        await Promise.allSettled(
+          resourcesToReload.map(resource => store.fetcher.load(resource, { force: true }))
+        )
       } catch (err) {
         debug.warn('Failed to refresh authenticated resources after login', err)
       }

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -430,73 +430,11 @@ function signInOrSignUpBox (
   signInPopUpButton.setAttribute('value', 'Log in')
   signInPopUpButton.setAttribute('style', `${signInButtonStyle}${style.headerBannerLoginInput}` + style.signUpBackground)
 
-  authSession.events.on('login', async () => {
+  authSession.events.on('login', () => {
     const me = authn.currentUser()
     // const sessionInfo = authSession.info
     // if (sessionInfo && sessionInfo.isLoggedIn) {
     if (me) {
-      // Ensure preferences and related settings files are initialized before
-      // resolving login boxes, to avoid transient 404s for settings resources.
-      let preferencesFile: NamedNode | undefined
-      try {
-        const ensured = await ensureLoadedPreferences({ me })
-        preferencesFile = ensured.preferencesFile as NamedNode | undefined
-      } catch (err) {
-        debug.warn('Failed to initialize preferences after login', err)
-      }
-
-      // Refresh key resources after login with authenticated fetch, but avoid
-      // destructive clears or forced navigation that can hide existing entries.
-      try {
-        const storageRoot = store.any(me, ns.space('storage')) as NamedNode | null
-        const resourcesToReload: NamedNode[] = []
-        const seenResources = new Set<string>()
-        const queueResource = (resource: NamedNode | null | undefined): void => {
-          if (!resource || seenResources.has(resource.uri)) return
-          seenResources.add(resource.uri)
-          resourcesToReload.push(resource)
-        }
-
-        queueResource(me.doc())
-        queueResource(storageRoot)
-        if (preferencesFile) {
-          const preferencesDoc = preferencesFile.doc()
-          const settingsContainer = preferencesDoc.dir()
-          queueResource(preferencesDoc)
-          queueResource(settingsContainer)
-
-          // If settings are under the advertised storage root, proactively load
-          // each ancestor container so folder UIs can discover the path via
-          // fetched containment data rather than synthesized triples.
-          if (storageRoot && settingsContainer) {
-            const normalizedRoot = storageRoot.uri.endsWith('/') ? storageRoot.uri : `${storageRoot.uri}/`
-            if (settingsContainer.uri.startsWith(normalizedRoot)) {
-              const relativeParts = settingsContainer.uri
-                .slice(normalizedRoot.length)
-                .split('/')
-                .filter(Boolean)
-              let cursor = normalizedRoot
-              for (const part of relativeParts) {
-                cursor += `${part}/`
-                queueResource(store.sym(cursor))
-              }
-            }
-          }
-
-        }
-
-        const currentUri = (dom.getElementById('UserURI') as HTMLInputElement | null)?.value
-        if (currentUri) {
-          queueResource(store.sym(currentUri))
-        }
-
-        await Promise.allSettled(
-          resourcesToReload.map(resource => store.fetcher.load(resource, { force: true }))
-        )
-      } catch (err) {
-        debug.warn('Failed to refresh authenticated resources after login', err)
-      }
-
       // const webIdURI = sessionInfo.webId
       const webIdURI = me.uri
       // setUserCallback(webIdURI)

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -1132,11 +1132,11 @@ export function newAppInstance (
  */
 export async function getUserRoles (): Promise<Array<NamedNode>> {
   const currentUser = authn.currentUser()
-   const sessionInfo = authSession.info
+  const sessionInfo = authSession.info
   if (!sessionInfo?.isLoggedIn || !sessionInfo?.webId) {
     return []
   }
-  
+
   if (!currentUser || currentUser.uri !== sessionInfo.webId) {
     return []
   }
@@ -1153,22 +1153,16 @@ export async function getUserRoles (): Promise<Array<NamedNode>> {
   }
 
   const run = (async (): Promise<Array<NamedNode>> => {
-
-    try {
-      const { me, preferencesFile, preferencesFileError } = await ensureLoadedPreferences({ me: currentUser })
-      if (!preferencesFile || preferencesFileError) {
-        throw new Error(preferencesFileError || 'Unable to load user preferences file.')
-      }
-      return solidLogicSingleton.store.each(
-        me,
-        ns.rdf('type'),
-        null,
-        preferencesFile.doc()
-      ) as NamedNode[]
-    } catch (error) {
-      debug.warn('Unable to fetch your preferences - this was the error: ', error)
+    const { me, preferencesFile, preferencesFileError } = await ensureLoadedPreferences({ me: currentUser })
+    if (!preferencesFile || preferencesFileError) {
+      throw new Error(preferencesFileError || 'Unable to load user preferences file.')
     }
-    return []
+    return solidLogicSingleton.store.each(
+      me,
+      ns.rdf('type'),
+      null,
+      preferencesFile.doc()
+    ) as NamedNode[]
   })()
 
   getUserRolesInFlight.set(webId, run)
@@ -1176,6 +1170,9 @@ export async function getUserRoles (): Promise<Array<NamedNode>> {
     const roles = await run
     cachedUserRolesByWebId.set(webId, roles)
     return roles
+  } catch (error) {
+    debug.warn('Unable to fetch your preferences - this was the error: ', error)
+    return []
   } finally {
     if (getUserRolesInFlight.get(webId) === run) {
       getUserRolesInFlight.delete(webId)

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -1131,12 +1131,12 @@ export function newAppInstance (
  * and/or a developer
  */
 export async function getUserRoles (): Promise<Array<NamedNode>> {
+  const currentUser = authn.currentUser()
    const sessionInfo = authSession.info
   if (!sessionInfo?.isLoggedIn || !sessionInfo?.webId) {
     return []
   }
   
-  const currentUser = authn.currentUser()
   if (!currentUser || currentUser.uri !== sessionInfo.webId) {
     return []
   }
@@ -1157,7 +1157,7 @@ export async function getUserRoles (): Promise<Array<NamedNode>> {
     try {
       const { me, preferencesFile, preferencesFileError } = await ensureLoadedPreferences({ me: currentUser })
       if (!preferencesFile || preferencesFileError) {
-        throw new Error(preferencesFileError) || 'Unable to load user preferences file.')
+        throw new Error(preferencesFileError || 'Unable to load user preferences file.')
       }
       return solidLogicSingleton.store.each(
         me,

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -65,6 +65,12 @@ const {
   deleteTypeIndexRegistration
 } = solidLogicSingleton.typeIndex
 
+// Dedupe/caching for preference loading across repeated UI callers.
+const ensureLoadedPreferencesInFlight = new Map<string, Promise<AuthenticationContext>>()
+const cachedPreferencesFileByWebId = new Map<string, NamedNode>()
+const getUserRolesInFlight = new Map<string, Promise<Array<NamedNode>>>()
+const cachedUserRolesByWebId = new Map<string, Array<NamedNode>>()
+
 /**
  * Resolves with the logged in user's WebID
  *
@@ -83,6 +89,7 @@ export function ensureLoggedIn (context: AuthenticationContext): Promise<Authent
       // Already logged in?
       if (webId) {
         debug.log(`logIn: Already logged in as ${webId}`)
+        authn.saveUser(webId as NamedNode | string, context)
         return resolve(context)
       }
       if (!context.div || !context.dom) {
@@ -110,6 +117,25 @@ export async function ensureLoadedPreferences (
   context: AuthenticationContext
 ): Promise<AuthenticationContext> {
   if (context.preferencesFile) return Promise.resolve(context) // already done
+
+  const webId = context?.me?.uri
+  if (webId) {
+    const cachedPreferencesFile = cachedPreferencesFileByWebId.get(webId)
+    if (cachedPreferencesFile) {
+      context.preferencesFile = cachedPreferencesFile
+      return context
+    }
+
+    const inFlight = ensureLoadedPreferencesInFlight.get(webId)
+    if (inFlight) {
+      const resolved = await inFlight
+      context.preferencesFile = resolved.preferencesFile
+      context.preferencesFileError = resolved.preferencesFileError
+      return context
+    }
+  }
+
+  const run = (async (): Promise<AuthenticationContext> => {
 
   // const statusArea = context.statusArea || context.div || null
   let progressDisplay
@@ -163,7 +189,24 @@ export async function ensureLoadedPreferences (
       throw new Error(`(via loadPrefs) ${err}`)
     }
   }
-  return context
+    return context
+  })()
+
+  if (webId) {
+    ensureLoadedPreferencesInFlight.set(webId, run)
+  }
+
+  try {
+    const resolved = await run
+    if (webId && resolved.preferencesFile) {
+      cachedPreferencesFileByWebId.set(webId, resolved.preferencesFile)
+    }
+    return resolved
+  } finally {
+    if (webId && ensureLoadedPreferencesInFlight.get(webId) === run) {
+      ensureLoadedPreferencesInFlight.delete(webId)
+    }
+  }
 }
 
 /**
@@ -387,11 +430,52 @@ function signInOrSignUpBox (
   signInPopUpButton.setAttribute('value', 'Log in')
   signInPopUpButton.setAttribute('style', `${signInButtonStyle}${style.headerBannerLoginInput}` + style.signUpBackground)
 
-  authSession.events.on('login', () => {
+  authSession.events.on('login', async () => {
     const me = authn.currentUser()
     // const sessionInfo = authSession.info
     // if (sessionInfo && sessionInfo.isLoggedIn) {
     if (me) {
+      // Ensure preferences and related settings files are initialized before
+      // resolving login boxes, to avoid transient 404s for settings resources.
+      let preferencesFile: NamedNode | undefined
+      try {
+        const ensured = await ensureLoadedPreferences({ me })
+        preferencesFile = ensured.preferencesFile as NamedNode | undefined
+      } catch (err) {
+        debug.warn('Failed to initialize preferences after login', err)
+      }
+
+      // Refresh key resources after login with authenticated fetch, but avoid
+      // destructive clears or forced navigation that can hide existing entries.
+      try {
+        const storageRoot = store.any(me, ns.space('storage')) as NamedNode | null
+        if (storageRoot) {
+          await store.fetcher.load(storageRoot, { force: true })
+        }
+
+        if (preferencesFile) {
+          const settingsContainer = preferencesFile.doc().dir()
+          if (settingsContainer) {
+            await store.fetcher.load(settingsContainer, { force: true })
+
+            // Some servers or cached container states may omit settings from
+            // the visible root listing even when the container exists.
+            // Ensure folder UIs can discover it from local store state.
+            if (storageRoot &&
+              !store.holds(storageRoot, ns.ldp('contains'), settingsContainer, storageRoot.doc())) {
+              store.add(storageRoot, ns.ldp('contains'), settingsContainer, storageRoot.doc())
+            }
+          }
+        }
+
+        const currentUri = (dom.getElementById('UserURI') as HTMLInputElement | null)?.value
+        if (currentUri) {
+          await store.fetcher.load(store.sym(currentUri), { force: true })
+        }
+      } catch (err) {
+        debug.warn('Failed to refresh authenticated resources after login', err)
+      }
+
       // const webIdURI = sessionInfo.webId
       const webIdURI = me.uri
       // setUserCallback(webIdURI)
@@ -1047,26 +1131,56 @@ export function newAppInstance (
  * and/or a developer
  */
 export async function getUserRoles (): Promise<Array<NamedNode>> {
-  const currentUser = authn.currentUser()
-  if (!currentUser) {
+  const sessionInfo = authSession.info
+  if (!sessionInfo?.isLoggedIn || !sessionInfo?.webId) {
     return []
   }
 
-  try {
-    const { me, preferencesFile, preferencesFileError } = await ensureLoadedPreferences({ me: currentUser })
-    if (!preferencesFile || preferencesFileError) {
-      return []
-    }
-    return solidLogicSingleton.store.each(
-      me,
-      ns.rdf('type'),
-      null,
-      preferencesFile.doc()
-    ) as NamedNode[]
-  } catch (error) {
-    debug.warn('Unable to fetch your preferences - this was the error: ', error)
+  const currentUser = authn.currentUser()
+  if (!currentUser || currentUser.uri !== sessionInfo.webId) {
+    return []
   }
-  return []
+
+  const webId = currentUser.uri
+  const cachedUserRoles = cachedUserRolesByWebId.get(webId)
+  if (cachedUserRoles) {
+    return cachedUserRoles
+  }
+
+  const inFlight = getUserRolesInFlight.get(webId)
+  if (inFlight) {
+    return inFlight
+  }
+
+  const run = (async (): Promise<Array<NamedNode>> => {
+
+    try {
+      const { me, preferencesFile, preferencesFileError } = await ensureLoadedPreferences({ me: currentUser })
+      if (!preferencesFile || preferencesFileError) {
+        throw new Error(preferencesFileError)
+      }
+      return solidLogicSingleton.store.each(
+        me,
+        ns.rdf('type'),
+        null,
+        preferencesFile.doc()
+      ) as NamedNode[]
+    } catch (error) {
+      debug.warn('Unable to fetch your preferences - this was the error: ', error)
+    }
+    return []
+  })()
+
+  getUserRolesInFlight.set(webId, run)
+  try {
+    const roles = await run
+    cachedUserRolesByWebId.set(webId, roles)
+    return roles
+  } finally {
+    if (getUserRolesInFlight.get(webId) === run) {
+      getUserRolesInFlight.delete(webId)
+    }
+  }
 }
 
 /**

--- a/test/unit/login/login.test.ts
+++ b/test/unit/login/login.test.ts
@@ -11,6 +11,7 @@ function buildSolidLogicMock () {
     add: jest.fn(),
     sym,
     fetcher: {
+      requested: {},
       load: jest.fn(async () => undefined)
     }
   }
@@ -169,5 +170,44 @@ describe('getUserRoles', () => {
     expect(second).toEqual([role])
     expect(loadPreferences).toHaveBeenCalledTimes(2)
     expect(store.each).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not clear cached storage request failures during login UI handling', async () => {
+    const { loginModule, solidLogic, store } = loadLoginWithMock()
+
+    const me = sym('https://alice.example.com/profile/card#me')
+    const initialRequested = {
+      'https://alice.example.com/settings/': 404,
+      'https://alice.example.com/private/notes.ttl': 404,
+      'https://other.example.com/resource.ttl': 404
+    }
+    store.fetcher.requested = { ...initialRequested }
+
+    const dom = document.implementation.createHTMLDocument('login-test')
+    const userUriInput = dom.createElement('input')
+    userUriInput.id = 'UserURI'
+    userUriInput.value = 'https://alice.example.com/private/notes.ttl'
+    dom.body.appendChild(userUriInput)
+
+    solidLogic.authn.currentUser
+      .mockReturnValueOnce(null)
+      .mockReturnValue(me)
+      .mockReturnValue(me)
+
+    const box = loginModule.loginStatusBox(dom, jest.fn())
+    dom.body.appendChild(box)
+
+    const loginHandlers = solidLogic.authSession.events.on.mock.calls
+      .filter(([eventName]) => eventName === 'login')
+      .map(([, handler]) => handler)
+
+    expect(loginHandlers.length).toBeGreaterThan(0)
+    for (const handler of loginHandlers) {
+      await handler()
+    }
+
+    expect(store.fetcher.requested['https://alice.example.com/settings/']).toBe(404)
+    expect(store.fetcher.requested['https://alice.example.com/private/notes.ttl']).toBe(404)
+    expect(store.fetcher.requested['https://other.example.com/resource.ttl']).toBe(404)
   })
 })

--- a/test/unit/login/login.test.ts
+++ b/test/unit/login/login.test.ts
@@ -1,4 +1,68 @@
 import * as testLogin from '../../../src/login/login'
+import { sym } from 'rdflib'
+
+function buildSolidLogicMock () {
+  const loadPreferences = jest.fn()
+  const loadProfile = jest.fn(async (me) => me?.doc?.() ?? me)
+  const store = {
+    each: jest.fn(() => []),
+    any: jest.fn(() => null),
+    holds: jest.fn(() => false),
+    add: jest.fn(),
+    sym,
+    fetcher: {
+      load: jest.fn(async () => undefined)
+    }
+  }
+
+  const mockModule = {
+    AppDetails: class AppDetails {},
+    AuthenticationContext: class AuthenticationContext {},
+    authn: {
+      currentUser: jest.fn(() => null),
+      checkUser: jest.fn(async () => null),
+      saveUser: jest.fn((user) => user)
+    },
+    authSession: {
+      info: { isLoggedIn: false, webId: undefined },
+      events: { on: jest.fn() },
+      login: jest.fn(async () => undefined),
+      logout: jest.fn(async () => undefined)
+    },
+    CrossOriginForbiddenError: class CrossOriginForbiddenError extends Error {},
+    FetchError: class FetchError extends Error { status?: number },
+    getSuggestedIssuers: jest.fn(() => []),
+    NotEditableError: class NotEditableError extends Error {},
+    offlineTestID: jest.fn(() => null),
+    SameOriginForbiddenError: class SameOriginForbiddenError extends Error {},
+    UnauthorizedError: class UnauthorizedError extends Error {},
+    WebOperationError: class WebOperationError extends Error {},
+    store,
+    solidLogicSingleton: {
+      store,
+      profile: {
+        loadPreferences,
+        loadProfile
+      },
+      typeIndex: {
+        getScopedAppInstances: jest.fn(async () => []),
+        getRegistrations: jest.fn(() => []),
+        loadAllTypeIndexes: jest.fn(async () => []),
+        getScopedAppsFromIndex: jest.fn(async () => []),
+        deleteTypeIndexRegistration: jest.fn(async () => undefined)
+      }
+    }
+  }
+
+  return { mockModule, loadPreferences, store }
+}
+
+function loadLoginWithMock () {
+  const { mockModule, loadPreferences, store } = buildSolidLogicMock()
+  jest.doMock('solid-logic', () => mockModule)
+  const loginModule = require('../../../src/login/login')
+  return { loginModule, solidLogic: mockModule, loadPreferences, store }
+}
 
 describe('ensureLoggedIn', () => {
   afterAll(() => {
@@ -16,6 +80,7 @@ describe('getUserRoles', () => {
   afterEach(() => {
     jest.restoreAllMocks()
     jest.resetModules()
+    jest.clearAllMocks()
   })
 
   it('returns [] and does not load preferences when current user is missing', async () => {
@@ -35,5 +100,74 @@ describe('getUserRoles', () => {
     expect(currentUserSpy).toHaveBeenCalled()
     expect(roles).toEqual([])
     expect(loadPreferencesSpy).not.toHaveBeenCalled()
+  })
+
+  it('shares in-flight ensureLoadedPreferences work for concurrent callers', async () => {
+    const { loginModule, solidLogic, loadPreferences } = loadLoginWithMock()
+
+    const me = sym('https://alice.example.com/profile/card#me')
+    let resolvePreferences: (value: any) => void = () => {}
+    const preferencesFile = sym('https://alice.example.com/settings/prefs.ttl')
+
+    solidLogic.authn.currentUser.mockReturnValue(me)
+    loadPreferences.mockImplementation(() => new Promise((resolve) => {
+      resolvePreferences = resolve
+    }))
+
+    const p1 = loginModule.ensureLoadedPreferences({ me, publicProfile: me.doc() })
+    const p2 = loginModule.ensureLoadedPreferences({ me, publicProfile: me.doc() })
+
+    await Promise.resolve()
+    expect(loadPreferences).toHaveBeenCalledTimes(1)
+
+    resolvePreferences(preferencesFile)
+    const [first, second] = await Promise.all([p1, p2])
+
+    expect(first.preferencesFile).toEqual(preferencesFile)
+    expect(second.preferencesFile).toEqual(preferencesFile)
+    expect(loadPreferences).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches successful role lookups per WebID', async () => {
+    const { loginModule, solidLogic, loadPreferences, store } = loadLoginWithMock()
+
+    const me = sym('https://alice.example.com/profile/card#me')
+    const preferencesFile = sym('https://alice.example.com/settings/prefs.ttl')
+    const role = sym('http://example.com/ns#PowerUser')
+
+    solidLogic.authSession.info = { isLoggedIn: true, webId: me.uri }
+    solidLogic.authn.currentUser.mockReturnValue(me)
+    loadPreferences.mockResolvedValue(preferencesFile)
+    store.each.mockReturnValue([role])
+
+    const first = await loginModule.getUserRoles()
+    const second = await loginModule.getUserRoles()
+
+    expect(first).toEqual([role])
+    expect(second).toEqual([role])
+    expect(loadPreferences).toHaveBeenCalledTimes(1)
+    expect(store.each).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not cache failed role lookups', async () => {
+    const { loginModule, solidLogic, loadPreferences, store } = loadLoginWithMock()
+
+    const me = sym('https://alice.example.com/profile/card#me')
+    const preferencesFile = sym('https://alice.example.com/settings/prefs.ttl')
+    const role = sym('http://example.com/ns#Developer')
+
+    solidLogic.authSession.info = { isLoggedIn: true, webId: me.uri }
+    solidLogic.authn.currentUser.mockReturnValue(me)
+    loadPreferences.mockRejectedValueOnce(new Error('transient failure'))
+    loadPreferences.mockResolvedValueOnce(preferencesFile)
+    store.each.mockReturnValue([role])
+
+    const first = await loginModule.getUserRoles()
+    const second = await loginModule.getUserRoles()
+
+    expect(first).toEqual([])
+    expect(second).toEqual([role])
+    expect(loadPreferences).toHaveBeenCalledTimes(2)
+    expect(store.each).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Ticket https://github.com/SolidOS/solid-ui/issues/464
The work creating on PR https://github.com/SolidOS/solid-logic/pull/238 creating the settings files to be like the server creates them brought to light some issues with GetUserRoles being called multiple times during the login session causing race conditions to happen with the file creation that could potentially happen in loadPreferences if the settings files for a user do not exist.

Also there was a problem with the settings folder appearing after creation. It either did not appear or gave a 404 error when shown. This is fixed in this PR. 
