### PR TITLE
a11y: demote tab-widget body from <main> to <div>

### DIFF
--- a/src/tabs.ts
+++ b/src/tabs.ts
@@ -187,7 +187,7 @@ export function tabWidget (options: TabWidgetOptions) {
   const navElement = rootElement.appendChild(dom.createElement('nav'))
   navElement.setAttribute('style', style.tabsNavElement)
 
-  const mainElement = rootElement.appendChild(dom.createElement('main'))
+  const mainElement = rootElement.appendChild(dom.createElement('div'))
 
   mainElement.setAttribute('style', style.tabsMainElement) // override tabbedtab.css
   const tabContainer = navElement.appendChild(dom.createElement('ul'))
@@ -333,7 +333,7 @@ export function tabWidget (options: TabWidgetOptions) {
     function getOrCreateContainerElement (ele: TabElement): ContainerElement {
       const bodyMain = ele.bodyTR?.children[0] as ContainerElement
       if (bodyMain) return bodyMain
-      const newBodyMain = ele.bodyTR!.appendChild(dom.createElement('main'))
+      const newBodyMain = ele.bodyTR!.appendChild(dom.createElement('div'))
       newBodyMain.setAttribute('style', bodyMainStyle)
       return newBodyMain
     }


### PR DESCRIPTION
## Summary
- The tab widget previously created `<main>` elements for both its outer body container and per-tab body. Combined with the shell's own `<main>`, each tabbed pane view had two or more `<main>` landmarks per page.
- The page-level `<main>` landmark now lives on the shell's `.app-view` (see SolidOS/mashlib#394). Tab widget internals become plain `<div>`s so we have exactly one `<main>` per page.
- No styling change: the widget uses `style.tabsMainElement` and `bodyMainStyle` inline, not a `main` selector.

Addresses SolidOS/profile-pane#310.

## Coordinated PRs
- SolidOS/mashlib#394 — Promote `.app-view` to the page-level `<main>` landmark (land first)
- SolidOS/profile-pane#312 — Drop inner `<main>` from ProfileView and EditProfileView