### PR TITLE
replace Inrupt by Uvdsl OIDC client

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,3 +1,14 @@
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const localSolidLogicSrc = path.resolve(__dirname, '../solid-logic/src')
+const solidLogicMapper = existsSync(localSolidLogicSrc)
+  ? localSolidLogicSrc
+  : '<rootDir>/node_modules/solid-logic/src'
+
 export default {
   // verbose: true, // Uncomment for detailed test output
   collectCoverage: true,
@@ -17,7 +28,7 @@ export default {
   moduleNameMapper: {
     '^~icons/(.*)$': '<rootDir>/__mocks__/iconsMock.js',
     '^.+\\.css$': '<rootDir>/__mocks__/styleMock.js',
-    '^solid-logic$': '<rootDir>/../solid-logic/src',
+    '^solid-logic$': solidLogicMapper,
     '^@uvdsl/solid-oidc-client-browser$': '<rootDir>/test/mocks/solid-oidc-client-browser.ts'
   },
   testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -16,7 +16,9 @@ export default {
   setupFilesAfterEnv: ['./test/helpers/setup.ts'],
   moduleNameMapper: {
     '^~icons/(.*)$': '<rootDir>/__mocks__/iconsMock.js',
-    '^.+\\.css$': '<rootDir>/__mocks__/styleMock.js'
+    '^.+\\.css$': '<rootDir>/__mocks__/styleMock.js',
+    '^solid-logic$': '<rootDir>/../solid-logic/src',
+    '^@uvdsl/solid-oidc-client-browser$': '<rootDir>/test/mocks/solid-oidc-client-browser.ts'
   },
   testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
   roots: ['<rootDir>/src', '<rootDir>/test', '<rootDir>/__mocks__'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "solid-ui",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "solid-ui",
-			"version": "3.1.1",
+			"version": "3.1.2",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "solid-ui",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"description": "UI library for Solid applications",
 	"main": "dist/solid-ui.js",
 	"types": "dist/index.d.ts",

--- a/src/design-system/lib/auth/SolidAuth.ts
+++ b/src/design-system/lib/auth/SolidAuth.ts
@@ -13,11 +13,13 @@ export default class SolidAuth implements AuthContext {
   constructor (public signupUrl: string = DEFAULT_SIGNUP_URL) {}
 
   get account (): Account | null {
-    if (!authSession.info?.isLoggedIn || !authSession.info?.webId) {
+    const sessionAny = authSession as any
+    const webId: string | undefined = sessionAny.webId ?? sessionAny.info?.webId
+    const isActive: boolean = sessionAny.isActive ?? sessionAny.info?.isLoggedIn ?? Boolean(webId)
+    if (!isActive || !webId) {
       return null
     }
 
-    const webId = authSession.info.webId
     const me = solidLogicSingleton.store.sym(webId)
     const avatarUrl = findImage(me) ?? undefined
 
@@ -44,10 +46,7 @@ export default class SolidAuth implements AuthContext {
 
     locationUrl.hash = ''
 
-    await authSession.login({
-      redirectUrl: locationUrl.href,
-      oidcIssuer: loginUrl
-    })
+    await (authSession as any).login(loginUrl, locationUrl.href)
   }
 
   async signup () {
@@ -59,14 +58,27 @@ export default class SolidAuth implements AuthContext {
   }
 
   onSessionUpdated (callback: () => unknown) {
-    authSession.events.on('login', callback)
-    authSession.events.on('logout', callback)
-    authSession.events.on('sessionRestore', callback)
+    const sessionEventTarget = authSession as unknown as EventTarget
+    const sessionAny = authSession as any
+    const listener = () => {
+      callback()
+    }
+    if (typeof sessionEventTarget.addEventListener === 'function') {
+      sessionEventTarget.addEventListener('sessionStateChange', listener)
+    } else {
+      sessionAny.events.on('login', callback)
+      sessionAny.events.on('logout', callback)
+      sessionAny.events.on('sessionRestore', callback)
+    }
 
     return () => {
-      authSession.events.off('login', callback)
-      authSession.events.off('logout', callback)
-      authSession.events.off('sessionRestore', callback)
+      if (typeof sessionEventTarget.removeEventListener === 'function') {
+        sessionEventTarget.removeEventListener('sessionStateChange', listener)
+      } else {
+        sessionAny.events.off('login', callback)
+        sessionAny.events.off('logout', callback)
+        sessionAny.events.off('sessionRestore', callback)
+      }
     }
   }
 }

--- a/src/design-system/lib/auth/SolidAuth.ts
+++ b/src/design-system/lib/auth/SolidAuth.ts
@@ -27,9 +27,8 @@ export default class SolidAuth implements AuthContext {
   constructor (public signupUrl: string = DEFAULT_SIGNUP_URL) {}
 
   get account (): Account | null {
-    const sessionAny = authSession as any
-    const webId: string | undefined = sessionAny.webId ?? sessionAny.info?.webId
-    const isActive: boolean = sessionAny.isActive ?? sessionAny.info?.isLoggedIn ?? Boolean(webId)
+    const webId: string | undefined = authSession.webId ?? authSession.info?.webId
+    const isActive: boolean = authSession.isActive ?? authSession.info?.isLoggedIn ?? Boolean(webId)
     if (!isActive || !webId) {
       return null
     }
@@ -59,7 +58,7 @@ export default class SolidAuth implements AuthContext {
 
     locationUrl.hash = ''
 
-    await (authSession as any).login(loginUrl, locationUrl.href)
+    await authSession.login(loginUrl, locationUrl.href)
   }
 
   async signup () {
@@ -72,25 +71,24 @@ export default class SolidAuth implements AuthContext {
 
   onSessionUpdated (callback: () => unknown) {
     const sessionEventTarget = authSession as unknown as EventTarget
-    const sessionAny = authSession as any
     const listener = () => {
       callback()
     }
     if (typeof sessionEventTarget.addEventListener === 'function') {
       sessionEventTarget.addEventListener('sessionStateChange', listener)
     } else {
-      sessionAny.events.on('login', callback)
-      sessionAny.events.on('logout', callback)
-      sessionAny.events.on('sessionRestore', callback)
+      authSession.events.on('login', callback)
+      authSession.events.on('logout', callback)
+      authSession.events.on('sessionRestore', callback)
     }
 
     return () => {
       if (typeof sessionEventTarget.removeEventListener === 'function') {
         sessionEventTarget.removeEventListener('sessionStateChange', listener)
       } else {
-        sessionAny.events.off('login', callback)
-        sessionAny.events.off('logout', callback)
-        sessionAny.events.off('sessionRestore', callback)
+        authSession.events.off('login', callback)
+        authSession.events.off('logout', callback)
+        authSession.events.off('sessionRestore', callback)
       }
     }
   }

--- a/src/design-system/lib/auth/SolidAuth.ts
+++ b/src/design-system/lib/auth/SolidAuth.ts
@@ -1,13 +1,27 @@
 import { authSession, solidLogicSingleton } from 'solid-logic'
 import Account from '../../../primitives/lib/auth/Account'
-import { findImage } from '../../../widgets/buttons'
 import { AuthContext } from '../../../primitives/lib/auth/context'
 import { showDialog } from '../dialogs'
 import { html } from 'lit'
+import ns from '../../../ns'
 
 import '../../components/login-modal'
 
 export const DEFAULT_SIGNUP_URL = 'https://solidproject.org/get_a_pod'
+
+function findAccountImage (webId: string): string | undefined {
+  const store = solidLogicSingleton.store
+  const me = store.sym(webId)
+  const image =
+    store.any(me, ns.sioc('avatar')) ||
+    store.any(me, ns.foaf('img')) ||
+    store.any(me, ns.vcard('logo')) ||
+    store.any(me, ns.vcard('hasPhoto')) ||
+    store.any(me, ns.vcard('photo')) ||
+    store.any(me, ns.foaf('depiction'))
+
+  return image ? (image as any).value : undefined
+}
 
 export default class SolidAuth implements AuthContext {
   constructor (public signupUrl: string = DEFAULT_SIGNUP_URL) {}
@@ -20,8 +34,7 @@ export default class SolidAuth implements AuthContext {
       return null
     }
 
-    const me = solidLogicSingleton.store.sym(webId)
-    const avatarUrl = findImage(me) ?? undefined
+    const avatarUrl = findAccountImage(webId)
 
     return new Account(webId, avatarUrl)
   }

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -162,6 +162,8 @@ export async function ensureLoadedPreferences (
     } else {
       throw new Error(`(via loadPrefs) ${err}`)
     }
+
+    context.preferencesFileError = m2
   }
   return context
 }
@@ -1050,22 +1052,10 @@ export function newAppInstance (
  * and/or a developer
  */
 export async function getUserRoles (): Promise<Array<NamedNode>> {
-  const sessionInfo = authSession.info
-  if (!sessionInfo?.isLoggedIn || !sessionInfo?.webId) {
-    return []
-  }
-
-  const currentUser = authn.currentUser()
-  if (!currentUser) {
-    return []
-  }
-
   try {
-    const { me, preferencesFile, preferencesFileError } = await ensureLoadedPreferences({
-      me: currentUser
-    })
+    const { me, preferencesFile, preferencesFileError } = await ensureLoadedPreferences({})
     if (!preferencesFile || preferencesFileError) {
-      throw new Error(preferencesFileError || 'Unable to load user preferences file.')
+      throw new Error(preferencesFileError)
     }
     return solidLogicSingleton.store.each(
       me,

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -513,10 +513,7 @@ export function renderSignInPopup (dom: HTMLDocument) {
       // Login
       const locationUrl = new URL(window.location.href)
       locationUrl.hash = '' // remove hash part
-      await authSession.login({
-        redirectUrl: locationUrl.href,
-        oidcIssuer: issuerUri
-      })
+      await authSession.login(issuerUri, locationUrl.href)
     } catch (err) {
       alert(err.message)
     }
@@ -669,9 +666,9 @@ export function loginStatusBox (
   }
 
   box.refresh = function () {
-    const sessionInfo = authSession.info
-    if (sessionInfo && sessionInfo.webId && sessionInfo.isLoggedIn) {
-      me = solidLogicSingleton.store.sym(sessionInfo.webId)
+    const webId = authSession.webId
+    if (webId) {
+      me = solidLogicSingleton.store.sym(webId)
     } else {
       me = null
     }

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -52,45 +52,6 @@ import * as widgets from '../widgets'
 
 const store = solidLogicSingleton.store
 
-let oidcBootstrapInFlight: Promise<void> | null = null
-
-function hasOidcCallbackParams (): boolean {
-  if (typeof window === 'undefined') {
-    return false
-  }
-  try {
-    const params = new URL(window.location.href).searchParams
-    return params.has('code') && params.has('state')
-  } catch (_err) {
-    return false
-  }
-}
-
-function ensureOidcCallbackBootstrap (): Promise<void> {
-  if (!hasOidcCallbackParams()) {
-    return Promise.resolve()
-  }
-  if (oidcBootstrapInFlight) {
-    return oidcBootstrapInFlight
-  }
-
-  oidcBootstrapInFlight = (async () => {
-    try {
-      await authn.checkUser()
-      // Some auth stacks settle session state asynchronously after first check.
-      if (!authn.currentUser() && hasOidcCallbackParams()) {
-        await authn.checkUser()
-      }
-    } catch (err) {
-      debug.log('OIDC callback bootstrap failed in loginStatusBox: ' + err)
-    } finally {
-      oidcBootstrapInFlight = null
-    }
-  })()
-
-  return oidcBootstrapInFlight
-}
-
 const {
   loadPreferences,
   loadProfile
@@ -728,7 +689,6 @@ export function loginStatusBox (
     box.refresh()
   }
   trackSession()
-  void ensureOidcCallbackBootstrap().then(trackSession)
 
   authSession.events.on('login', trackSession)
   authSession.events.on('logout', trackSession)
@@ -762,17 +722,6 @@ authSession.events.on('logout', async () => {
     } catch (_err) {
       // Do nothing
     }
-  }
-
-  // Prevent re-processing stale OIDC callback parameters after logout reload.
-  try {
-    const url = new URL(window.location.href)
-    url.searchParams.delete('code')
-    url.searchParams.delete('state')
-    url.searchParams.delete('iss')
-    history.replaceState(null, document.title, `${url.pathname}${url.search}${url.hash}`)
-  } catch (_err) {
-    // Keep current URL if normalization fails.
   }
   window.location.reload()
 })

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -713,6 +713,12 @@ authSession.events.on('logout', async () => {
           await fetch(openidConfiguration.end_session_endpoint, { credentials: 'include' })
         }
       }
+
+      try {
+        await fetch('/.well-known/solid/logout', { credentials: 'include' })
+      } catch (_err) {
+        // Not all deployments expose NSS-compatible well-known logout endpoint.
+      }
     } catch (_err) {
       // Do nothing
     }

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -52,6 +52,45 @@ import * as widgets from '../widgets'
 
 const store = solidLogicSingleton.store
 
+let oidcBootstrapInFlight: Promise<void> | null = null
+
+function hasOidcCallbackParams (): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  try {
+    const params = new URL(window.location.href).searchParams
+    return params.has('code') && params.has('state')
+  } catch (_err) {
+    return false
+  }
+}
+
+function ensureOidcCallbackBootstrap (): Promise<void> {
+  if (!hasOidcCallbackParams()) {
+    return Promise.resolve()
+  }
+  if (oidcBootstrapInFlight) {
+    return oidcBootstrapInFlight
+  }
+
+  oidcBootstrapInFlight = (async () => {
+    try {
+      await authn.checkUser()
+      // Some auth stacks settle session state asynchronously after first check.
+      if (!authn.currentUser() && hasOidcCallbackParams()) {
+        await authn.checkUser()
+      }
+    } catch (err) {
+      debug.log('OIDC callback bootstrap failed in loginStatusBox: ' + err)
+    } finally {
+      oidcBootstrapInFlight = null
+    }
+  })()
+
+  return oidcBootstrapInFlight
+}
+
 const {
   loadPreferences,
   loadProfile
@@ -689,6 +728,7 @@ export function loginStatusBox (
     box.refresh()
   }
   trackSession()
+  void ensureOidcCallbackBootstrap().then(trackSession)
 
   authSession.events.on('login', trackSession)
   authSession.events.on('logout', trackSession)
@@ -722,6 +762,17 @@ authSession.events.on('logout', async () => {
     } catch (_err) {
       // Do nothing
     }
+  }
+
+  // Prevent re-processing stale OIDC callback parameters after logout reload.
+  try {
+    const url = new URL(window.location.href)
+    url.searchParams.delete('code')
+    url.searchParams.delete('state')
+    url.searchParams.delete('iss')
+    history.replaceState(null, document.title, `${url.pathname}${url.search}${url.hash}`)
+  } catch (_err) {
+    // Keep current URL if normalization fails.
   }
   window.location.reload()
 })

--- a/src/v2/components/auth/loginButton/LoginButton.ts
+++ b/src/v2/components/auth/loginButton/LoginButton.ts
@@ -419,10 +419,7 @@ export class LoginButton extends LitElement {
 
       const locationUrl = new URL(window.location.href)
       locationUrl.hash = ''
-      await authSession.login({
-        redirectUrl: locationUrl.href,
-        oidcIssuer: issuerUri
-      })
+      await authSession.login(issuerUri, locationUrl.href)
     } catch (err: any) {
       this._errorMsg = err.message || String(err)
       this.requestUpdate()

--- a/src/v2/components/layout/footer/Footer.ts
+++ b/src/v2/components/layout/footer/Footer.ts
@@ -107,9 +107,6 @@ export class Footer extends LitElement {
     if (typeof authSession.events.off === 'function') {
       authSession.events.off('login', this._updateFooter)
       authSession.events.off('logout', this._updateFooter)
-    } else if (typeof authSession.events.removeListener === 'function') {
-      authSession.events.removeListener('login', this._updateFooter)
-      authSession.events.removeListener('logout', this._updateFooter)
     }
     super.disconnectedCallback()
   }

--- a/src/v2/components/layout/header/Header.ts
+++ b/src/v2/components/layout/header/Header.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from 'lit'
 import { icons } from '../../../../iconBase'
-import { authSession, authn } from 'solid-logic'
+import { authSession, authn, performServerSideLogout } from 'solid-logic'
 import '../../auth/loginButton/index'
 import '../../auth/signupButton/index'
 import { ifDefined } from 'lit/directives/if-defined.js'
@@ -13,6 +13,36 @@ const DEFAULT_HELP_MENU_ICON = ''
 const DEFAULT_SOLID_ICON_URL = 'https://solidproject.org/assets/img/solid-emblem.svg'
 const DEFAULT_SIGNUP_URL = 'https://solidproject.org/get_a_pod'
 const DEFAULT_LOGGEDIN_MENU_BUTTON_AVATAR = icons.iconBase + 'emptyProfileAvatar.png'
+
+async function clearPersistedAuthState (): Promise<void> {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const explicitKeys = ['loginIssuer', 'preLoginRedirectHash']
+  for (const key of explicitKeys) {
+    window.localStorage.removeItem(key)
+    window.sessionStorage.removeItem(key)
+  }
+
+  if (typeof indexedDB === 'undefined') {
+    return
+  }
+
+  const databases = ['soidc', 'solid-client-authn-store', 'solid-client-authn']
+  for (const dbName of databases) {
+    await new Promise<void>((resolve) => {
+      try {
+        const request = indexedDB.deleteDatabase(dbName)
+        request.onsuccess = () => resolve()
+        request.onerror = () => resolve()
+        request.onblocked = () => resolve()
+      } catch (_err) {
+        resolve()
+      }
+    })
+  }
+}
 
 export type HeaderAuthState = 'logged-out' | 'logged-in'
 
@@ -51,7 +81,8 @@ export class Header extends LitElement {
     accountMenuOpen: { state: true },
     helpMenuOpen: { state: true },
     hasSlottedAccountMenu: { state: true },
-    hasSlottedHelpMenu: { state: true }
+    hasSlottedHelpMenu: { state: true },
+    authResolved: { state: true }
   }
 
   static styles = css`
@@ -514,8 +545,11 @@ export class Header extends LitElement {
   declare helpMenuOpen: boolean
   declare hasSlottedAccountMenu: boolean
   declare hasSlottedHelpMenu: boolean
+  declare authResolved: boolean
+  private _refreshPromise: Promise<void> | null = null
+
   private readonly handleAuthSessionChange = () => {
-    this.refreshAuthStateFromSession()
+    void this.refreshAuthStateFromSession()
   }
 
   constructor () {
@@ -541,6 +575,7 @@ export class Header extends LitElement {
     this.helpMenuOpen = false
     this.hasSlottedAccountMenu = false
     this.hasSlottedHelpMenu = false
+    this.authResolved = false
   }
 
   connectedCallback () {
@@ -552,7 +587,7 @@ export class Header extends LitElement {
       authSession.events.on('logout', this.handleAuthSessionChange)
       authSession.events.on('sessionRestore', this.handleAuthSessionChange)
     }
-    this.refreshAuthStateFromSession()
+    void this.refreshAuthStateFromSession()
   }
 
   disconnectedCallback () {
@@ -567,12 +602,28 @@ export class Header extends LitElement {
   }
 
   private async refreshAuthStateFromSession () {
-    try {
-      await authn.checkUser()
-    } catch (_err) {
-      // Keep rendering even if session refresh cannot complete.
+    if (!this._refreshPromise) {
+      this._refreshPromise = (async () => {
+        try {
+          await authn.checkUser()
+          // Some auth stacks resolve session state asynchronously after first check.
+          if (!authn.currentUser()) {
+            await authn.checkUser()
+          }
+        } catch (_err) {
+          // Keep rendering even if session refresh cannot complete.
+        }
+      })()
     }
+
+    try {
+      await this._refreshPromise
+    } finally {
+      this._refreshPromise = null
+    }
+
     this.authState = authn.currentUser() ? 'logged-in' : 'logged-out'
+    this.authResolved = true
   }
 
   private handleHelpMenuClick (item: HeaderMenuItem, event: MouseEvent) {
@@ -711,7 +762,15 @@ export class Header extends LitElement {
       // logout errors are non-fatal — proceed to clear state
     }
 
-    await this.performServerLogout(issuer)
+    await clearPersistedAuthState()
+
+    const redirectedToServerLogout = await performServerSideLogout({
+      issuer,
+      postLogoutRedirectPath: '/'
+    })
+    if (redirectedToServerLogout) {
+      return
+    }
 
     await this.refreshAuthStateFromSession()
     this.dispatchEvent(new CustomEvent('logout-select', {
@@ -719,32 +778,6 @@ export class Header extends LitElement {
       bubbles: true,
       composed: true
     }))
-  }
-
-  private async performServerLogout (issuer: string) {
-    // Best-effort server logout for cookie-backed sessions on NSS-like servers.
-    try {
-      if (issuer) {
-        const wellKnownUri = new URL(issuer)
-        wellKnownUri.pathname = '/.well-known/openid-configuration'
-        const wellKnownResult = await fetch(wellKnownUri.toString(), { credentials: 'include' })
-
-        if (wellKnownResult.status === 200) {
-          const openidConfiguration = await wellKnownResult.json()
-          if (openidConfiguration && openidConfiguration.end_session_endpoint) {
-            await fetch(openidConfiguration.end_session_endpoint, { credentials: 'include' })
-          }
-        }
-      }
-    } catch (_err) {
-      // Continue with local logout state even if remote IdP logout is unavailable.
-    }
-
-    try {
-      await fetch('/.well-known/solid/logout', { credentials: 'include' })
-    } catch (_err) {
-      // Not all deployments expose NSS-compatible well-known logout.
-    }
   }
 
   private renderAccountMenuItem (item: HeaderAccountMenuItem) {
@@ -854,6 +887,10 @@ export class Header extends LitElement {
           <solid-ui-account></solid-ui-account>
         </solid-ui-provider>
       `
+    }
+
+    if (!this.authResolved) {
+      return html`<div class="auth-actions" part="auth-actions"></div>`
     }
 
     if (this.authState === 'logged-out') {

--- a/src/v2/components/layout/header/Header.ts
+++ b/src/v2/components/layout/header/Header.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from 'lit'
 import { icons } from '../../../../iconBase'
-import { authSession } from 'solid-logic'
+import { authSession, authn } from 'solid-logic'
 import '../../auth/loginButton/index'
 import '../../auth/signupButton/index'
 import { ifDefined } from 'lit/directives/if-defined.js'
@@ -514,6 +514,9 @@ export class Header extends LitElement {
   declare helpMenuOpen: boolean
   declare hasSlottedAccountMenu: boolean
   declare hasSlottedHelpMenu: boolean
+  private readonly handleAuthSessionChange = () => {
+    this.refreshAuthStateFromSession()
+  }
 
   constructor () {
     super()
@@ -544,12 +547,32 @@ export class Header extends LitElement {
     super.connectedCallback()
     document.addEventListener('click', this.handleDocumentClick)
     window.addEventListener('keydown', this.handleWindowKeydown)
+    if (typeof authSession.events?.on === 'function') {
+      authSession.events.on('login', this.handleAuthSessionChange)
+      authSession.events.on('logout', this.handleAuthSessionChange)
+      authSession.events.on('sessionRestore', this.handleAuthSessionChange)
+    }
+    this.refreshAuthStateFromSession()
   }
 
   disconnectedCallback () {
     document.removeEventListener('click', this.handleDocumentClick)
     window.removeEventListener('keydown', this.handleWindowKeydown)
+    if (typeof authSession.events?.off === 'function') {
+      authSession.events.off('login', this.handleAuthSessionChange)
+      authSession.events.off('logout', this.handleAuthSessionChange)
+      authSession.events.off('sessionRestore', this.handleAuthSessionChange)
+    }
     super.disconnectedCallback()
+  }
+
+  private async refreshAuthStateFromSession () {
+    try {
+      await authn.checkUser()
+    } catch (_err) {
+      // Keep rendering even if session refresh cannot complete.
+    }
+    this.authState = authn.currentUser() ? 'logged-in' : 'logged-out'
   }
 
   private handleHelpMenuClick (item: HeaderMenuItem, event: MouseEvent) {
@@ -669,8 +692,8 @@ export class Header extends LitElement {
     `
   }
 
-  private handleLoginSuccess () {
-    this.authState = 'logged-in'
+  private async handleLoginSuccess () {
+    await this.refreshAuthStateFromSession()
     this.dispatchEvent(new CustomEvent('auth-action-select', {
       detail: { role: 'login' },
       bubbles: true,
@@ -680,17 +703,48 @@ export class Header extends LitElement {
 
   private async handleLogout () {
     this.accountMenuOpen = false
+    const issuer = window.localStorage.getItem('loginIssuer') || ''
+
     try {
       await authSession.logout()
     } catch (_err) {
       // logout errors are non-fatal — proceed to clear state
     }
-    this.authState = 'logged-out'
+
+    await this.performServerLogout(issuer)
+
+    await this.refreshAuthStateFromSession()
     this.dispatchEvent(new CustomEvent('logout-select', {
       detail: { role: 'logout' },
       bubbles: true,
       composed: true
     }))
+  }
+
+  private async performServerLogout (issuer: string) {
+    // Best-effort server logout for cookie-backed sessions on NSS-like servers.
+    try {
+      if (issuer) {
+        const wellKnownUri = new URL(issuer)
+        wellKnownUri.pathname = '/.well-known/openid-configuration'
+        const wellKnownResult = await fetch(wellKnownUri.toString(), { credentials: 'include' })
+
+        if (wellKnownResult.status === 200) {
+          const openidConfiguration = await wellKnownResult.json()
+          if (openidConfiguration && openidConfiguration.end_session_endpoint) {
+            await fetch(openidConfiguration.end_session_endpoint, { credentials: 'include' })
+          }
+        }
+      }
+    } catch (_err) {
+      // Continue with local logout state even if remote IdP logout is unavailable.
+    }
+
+    try {
+      await fetch('/.well-known/solid/logout', { credentials: 'include' })
+    } catch (_err) {
+      // Not all deployments expose NSS-compatible well-known logout.
+    }
   }
 
   private renderAccountMenuItem (item: HeaderAccountMenuItem) {

--- a/src/v2/components/layout/header/Header.ts
+++ b/src/v2/components/layout/header/Header.ts
@@ -549,7 +549,9 @@ export class Header extends LitElement {
   private _refreshPromise: Promise<void> | null = null
 
   private readonly handleAuthSessionChange = () => {
-    void this.refreshAuthStateFromSession()
+    this.refreshAuthStateFromSession().catch(() => {
+      // Keep auth event handling resilient on transient refresh failures.
+    })
   }
 
   constructor () {
@@ -587,7 +589,9 @@ export class Header extends LitElement {
       authSession.events.on('logout', this.handleAuthSessionChange)
       authSession.events.on('sessionRestore', this.handleAuthSessionChange)
     }
-    void this.refreshAuthStateFromSession()
+    this.refreshAuthStateFromSession().catch(() => {
+      // Keep initial header render resilient on transient refresh failures.
+    })
   }
 
   disconnectedCallback () {

--- a/src/v2/components/layout/header/header.test.ts
+++ b/src/v2/components/layout/header/header.test.ts
@@ -11,6 +11,7 @@ jest.mock('solid-logic', () => ({
     checkUser: jest.fn(async () => null),
     currentUser: jest.fn(() => null)
   },
+  performServerSideLogout: jest.fn(async () => false),
   authSession: {
     logout: jest.fn(async () => undefined),
     events: {
@@ -354,6 +355,27 @@ describe('SolidUIHeaderElement', () => {
     await header.updateComplete
 
     expect(authn.checkUser).toHaveBeenCalled()
+    expect(header.authState).toBe('logged-in')
+  })
+
+  it('retries session resolution once before settling logged-out state', async () => {
+    const header = new Header()
+    let callCount = 0
+    ;(authn.currentUser as jest.Mock).mockImplementation(() => {
+      return callCount >= 2 ? { uri: 'https://alice.example/profile/card#me' } : null
+    })
+    ;(authn.checkUser as jest.Mock).mockImplementation(async () => {
+      callCount += 1
+      return callCount >= 2 ? { uri: 'https://alice.example/profile/card#me' } : null
+    })
+
+    document.body.appendChild(header)
+    await header.updateComplete
+    await Promise.resolve()
+    await header.updateComplete
+
+    expect(authn.checkUser).toHaveBeenCalledTimes(2)
+    expect(header.authResolved).toBe(true)
     expect(header.authState).toBe('logged-in')
   })
 

--- a/src/v2/components/layout/header/header.test.ts
+++ b/src/v2/components/layout/header/header.test.ts
@@ -30,6 +30,12 @@ jest.mock('solid-logic', () => ({
 }))
 
 describe('SolidUIHeaderElement', () => {
+  async function waitForAuthRefresh (header: Header): Promise<void> {
+    await Promise.resolve()
+    await Promise.resolve()
+    await header.updateComplete
+  }
+
   beforeEach(() => {
     Features.DESIGN_SYSTEM_HEADER_ACCOUNT = false
     document.body.innerHTML = ''
@@ -55,6 +61,7 @@ describe('SolidUIHeaderElement', () => {
     header.setAttribute('help-icon', 'https://example.com/help.png')
     header.setAttribute('brand-link', '/home')
     header.authState = 'logged-out'
+    header.authResolved = true
     header.helpMenuList = [{ label: 'Help', action: 'open-help' }]
     header.innerHTML = '<button slot="help-menu" id="helpBtn">Help</button>'
 
@@ -85,6 +92,7 @@ describe('SolidUIHeaderElement', () => {
     const authActionSelected = jest.fn()
 
     header.authState = 'logged-out'
+    header.authResolved = true
     header.loginAction = { label: 'Log in', action: 'login', icon: 'https://example.com/login-icon.svg' }
     header.signUpAction = { label: 'Sign Up', url: '/signup', icon: 'https://example.com/signup-icon.svg' }
     header.loginIcon = 'https://example.com/login-icon-top.svg'
@@ -110,8 +118,7 @@ describe('SolidUIHeaderElement', () => {
     expect(signUpLink.getAttribute('icon')).toBe('https://example.com/signup-icon-top.svg')
 
     loginButton.dispatchEvent(new CustomEvent('login-success', { bubbles: true, composed: true }))
-    await Promise.resolve()
-    await header.updateComplete
+    await waitForAuthRefresh(header)
 
     expect(authActionSelected).toHaveBeenCalledWith({
       role: 'login'
@@ -121,6 +128,7 @@ describe('SolidUIHeaderElement', () => {
   it('does not show login or signup icons on mobile layout', async () => {
     const header = new Header()
     header.authState = 'logged-out'
+    header.authResolved = true
     header.layout = 'mobile'
     header.loginAction = { label: 'Log in', action: 'login', icon: 'https://example.com/login-icon.svg' }
     header.signUpAction = { label: 'Sign Up', url: '/signup', icon: 'https://example.com/signup-icon.svg' }
@@ -143,6 +151,7 @@ describe('SolidUIHeaderElement', () => {
     ;(authn.currentUser as jest.Mock).mockReturnValue({ uri: 'https://alice.example/profile/card#me' })
 
     header.authState = 'logged-in'
+    header.authResolved = true
     header.accountAvatar = ''
     header.accountAvatarFallback = 'https://example.com/fallback-avatar.png'
 
@@ -162,6 +171,7 @@ describe('SolidUIHeaderElement', () => {
     ;(authn.currentUser as jest.Mock).mockReturnValue({ uri: 'https://alice.example/profile/card#me' })
 
     header.authState = 'logged-in'
+    header.authResolved = true
     header.accountIcon = 'https://example.com/account-icon.svg'
     header.accountAvatar = 'https://example.com/avatar.png'
     header.logoutIcon = 'https://example.com/logout-icon.svg'
@@ -213,6 +223,7 @@ describe('SolidUIHeaderElement', () => {
     ;(authn.currentUser as jest.Mock).mockReturnValue({ uri: 'https://alice.example/profile/card#me' })
     header.layout = 'mobile'
     header.authState = 'logged-in'
+    header.authResolved = true
     header.logoutIcon = 'https://example.com/logout-icon.svg'
     header.logoutLabel = 'Log Out'
 
@@ -237,6 +248,7 @@ describe('SolidUIHeaderElement', () => {
     ;(authn.currentUser as jest.Mock).mockReturnValue({ uri: 'https://alice.example/profile/card#me' })
     header.layout = 'mobile'
     header.authState = 'logged-in'
+    header.authResolved = true
     header.accountMenu = [
       { label: 'Personal Pod', webid: 'https://pod.example/profile/card#me', action: 'switch-personal' }
     ]
@@ -307,6 +319,7 @@ describe('SolidUIHeaderElement', () => {
     const helpMenuClicked = jest.fn()
 
     header.authState = 'logged-in'
+    header.authResolved = true
     header.helpIcon = ''
     header.helpMenuList = [{ label: 'Docs', url: 'https://example.com/docs', target: '_blank' }]
 
@@ -351,8 +364,7 @@ describe('SolidUIHeaderElement', () => {
 
     document.body.appendChild(header)
     await header.updateComplete
-    await Promise.resolve()
-    await header.updateComplete
+    await waitForAuthRefresh(header)
 
     expect(authn.checkUser).toHaveBeenCalled()
     expect(header.authState).toBe('logged-in')
@@ -386,14 +398,12 @@ describe('SolidUIHeaderElement', () => {
 
     ;(authn.currentUser as jest.Mock).mockReturnValue({ uri: 'https://alice.example/profile/card#me' })
     ;(authSession.events as any).emit('login')
-    await Promise.resolve()
-    await header.updateComplete
+    await waitForAuthRefresh(header)
     expect(header.authState).toBe('logged-in')
 
     ;(authn.currentUser as jest.Mock).mockReturnValue(null)
     ;(authSession.events as any).emit('logout')
-    await Promise.resolve()
-    await header.updateComplete
+    await waitForAuthRefresh(header)
     expect(header.authState).toBe('logged-out')
   })
 })

--- a/src/v2/components/layout/header/header.test.ts
+++ b/src/v2/components/layout/header/header.test.ts
@@ -1,11 +1,41 @@
 import Features from '../../../../features'
 import { Header } from './Header'
 import './index'
+import { authn, authSession } from 'solid-logic'
+
+type Listener = () => void
+const mockSessionListeners = new Map<string, Set<Listener>>()
+
+jest.mock('solid-logic', () => ({
+  authn: {
+    checkUser: jest.fn(async () => null),
+    currentUser: jest.fn(() => null)
+  },
+  authSession: {
+    logout: jest.fn(async () => undefined),
+    events: {
+      on: jest.fn((event: string, handler: Listener) => {
+        if (!mockSessionListeners.has(event)) mockSessionListeners.set(event, new Set())
+        mockSessionListeners.get(event)?.add(handler)
+      }),
+      off: jest.fn((event: string, handler: Listener) => {
+        mockSessionListeners.get(event)?.delete(handler)
+      }),
+      emit: jest.fn((event: string) => {
+        mockSessionListeners.get(event)?.forEach(handler => handler())
+      })
+    }
+  }
+}))
 
 describe('SolidUIHeaderElement', () => {
   beforeEach(() => {
     Features.DESIGN_SYSTEM_HEADER_ACCOUNT = false
     document.body.innerHTML = ''
+    jest.clearAllMocks()
+    mockSessionListeners.clear()
+    ;(authn.currentUser as jest.Mock).mockReturnValue(null)
+    ;(authn.checkUser as jest.Mock).mockResolvedValue(null)
     Object.defineProperty(window, 'open', {
       configurable: true,
       writable: true,
@@ -79,6 +109,8 @@ describe('SolidUIHeaderElement', () => {
     expect(signUpLink.getAttribute('icon')).toBe('https://example.com/signup-icon-top.svg')
 
     loginButton.dispatchEvent(new CustomEvent('login-success', { bubbles: true, composed: true }))
+    await Promise.resolve()
+    await header.updateComplete
 
     expect(authActionSelected).toHaveBeenCalledWith({
       role: 'login'
@@ -107,6 +139,7 @@ describe('SolidUIHeaderElement', () => {
 
   it('uses a custom fallback avatar when no accountAvatar is configured', async () => {
     const header = new Header()
+    ;(authn.currentUser as jest.Mock).mockReturnValue({ uri: 'https://alice.example/profile/card#me' })
 
     header.authState = 'logged-in'
     header.accountAvatar = ''
@@ -125,6 +158,7 @@ describe('SolidUIHeaderElement', () => {
   it('renders an accounts dropdown with avatar when logged in', async () => {
     const header = new Header()
     const accountMenuSelected = jest.fn()
+    ;(authn.currentUser as jest.Mock).mockReturnValue({ uri: 'https://alice.example/profile/card#me' })
 
     header.authState = 'logged-in'
     header.accountIcon = 'https://example.com/account-icon.svg'
@@ -175,6 +209,7 @@ describe('SolidUIHeaderElement', () => {
 
   it('does not render the logout icon on mobile layout', async () => {
     const header = new Header()
+    ;(authn.currentUser as jest.Mock).mockReturnValue({ uri: 'https://alice.example/profile/card#me' })
     header.layout = 'mobile'
     header.authState = 'logged-in'
     header.logoutIcon = 'https://example.com/logout-icon.svg'
@@ -198,6 +233,7 @@ describe('SolidUIHeaderElement', () => {
 
   it('does not render account webid on mobile layout', async () => {
     const header = new Header()
+    ;(authn.currentUser as jest.Mock).mockReturnValue({ uri: 'https://alice.example/profile/card#me' })
     header.layout = 'mobile'
     header.authState = 'logged-in'
     header.accountMenu = [
@@ -265,6 +301,7 @@ describe('SolidUIHeaderElement', () => {
 
   it('renders helpMenuList inside the help dropdown and dispatches events', async () => {
     const header = new Header()
+    ;(authn.currentUser as jest.Mock).mockReturnValue({ uri: 'https://alice.example/profile/card#me' })
 
     const helpMenuClicked = jest.fn()
 
@@ -305,5 +342,36 @@ describe('SolidUIHeaderElement', () => {
     expect(window.open).toHaveBeenCalledWith('https://example.com/docs', '_blank', 'noopener,noreferrer')
 
     window.open = originalWindowOpen
+  })
+
+  it('derives auth state from session on connect', async () => {
+    const header = new Header()
+    ;(authn.currentUser as jest.Mock).mockReturnValue({ uri: 'https://alice.example/profile/card#me' })
+
+    document.body.appendChild(header)
+    await header.updateComplete
+    await Promise.resolve()
+    await header.updateComplete
+
+    expect(authn.checkUser).toHaveBeenCalled()
+    expect(header.authState).toBe('logged-in')
+  })
+
+  it('refreshes auth state when session events fire', async () => {
+    const header = new Header()
+    document.body.appendChild(header)
+    await header.updateComplete
+
+    ;(authn.currentUser as jest.Mock).mockReturnValue({ uri: 'https://alice.example/profile/card#me' })
+    ;(authSession.events as any).emit('login')
+    await Promise.resolve()
+    await header.updateComplete
+    expect(header.authState).toBe('logged-in')
+
+    ;(authn.currentUser as jest.Mock).mockReturnValue(null)
+    ;(authSession.events as any).emit('logout')
+    await Promise.resolve()
+    await header.updateComplete
+    expect(header.authState).toBe('logged-out')
   })
 })

--- a/test/mocks/solid-oidc-client-browser.ts
+++ b/test/mocks/solid-oidc-client-browser.ts
@@ -1,0 +1,73 @@
+type Listener = (...args: any[]) => void
+
+class EventEmitterLike {
+  private listeners: Record<string, Listener[]> = {}
+
+  on (event: string, listener: Listener): void {
+    const list = this.listeners[event] || []
+    list.push(listener)
+    this.listeners[event] = list
+  }
+
+  off (event: string, listener: Listener): void {
+    const list = this.listeners[event] || []
+    this.listeners[event] = list.filter(item => item !== listener)
+  }
+
+  emit (event: string, ...args: any[]): void {
+    const list = this.listeners[event] || []
+    list.forEach(listener => listener(...args))
+  }
+}
+
+export class Session {
+  info: { webId?: string, isLoggedIn: boolean } = { isLoggedIn: false }
+  webId?: string
+  isActive = false
+  events = new EventEmitterLike()
+
+  private eventTarget = new EventTarget()
+
+  addEventListener (type: string, listener: EventListenerOrEventListenerObject | null): void {
+    if (!listener) return
+    this.eventTarget.addEventListener(type, listener)
+  }
+
+  removeEventListener (type: string, listener: EventListenerOrEventListenerObject | null): void {
+    if (!listener) return
+    this.eventTarget.removeEventListener(type, listener)
+  }
+
+  dispatchEvent (event: Event): boolean {
+    return this.eventTarget.dispatchEvent(event)
+  }
+
+  async handleIncomingRedirect (): Promise<void> {
+
+  }
+
+  async handleRedirectFromLogin (): Promise<void> {
+
+  }
+
+  async restore (): Promise<void> {
+
+  }
+
+  async login (_idp?: string, _redirectUri?: string): Promise<void> {
+  }
+
+  async logout (): Promise<void> {
+    this.info = { isLoggedIn: false }
+    this.webId = undefined
+    this.isActive = false
+  }
+
+  fetch (input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    return globalThis.fetch(input, init)
+  }
+
+  authFetch (input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    return globalThis.fetch(input, init)
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -64,7 +64,9 @@
     ] /* List of folders to include type definitions from. */,
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    "preserveSymlinks": true, /* Do not resolve the real path of symlinks. Needed for local linked solid-logic. */
+    "baseUrl": ".", /* Base directory to resolve non-absolute module names. Needed for paths mapping. */
+    "paths": { "rdflib": ["./node_modules/rdflib"] }, /* Map rdflib to avoid duplicate type identity when linked with solid-logic. */
 
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */


### PR DESCRIPTION
# Commit Notes - solid-ui (uvdsl contract adoption)

## Scope
Update solid-ui to consume the new uvdsl session contract directly and stabilize local integrated development with linked solid-logic.

## What changed
- Migrate login calls to new signature:
  - from object-style `{ oidcIssuer, redirectUrl }`
  - to positional `login(issuer, redirectUrl)`
- Replace auth session EventEmitter usage with EventTarget usage (`addEventListener('sessionStateChange', ...)`) where updated.
- Switch session state reads to the new contract (`webId` / `isActive`) with fallback only where still needed for integrated migration.

## Local integrated development notes kept intentionally
`tsconfig.json` includes settings to avoid duplicate rdflib type identities when solid-ui is linked with local solid-logic:
- `preserveSymlinks: true`
- `baseUrl` + `paths` mapping for `rdflib`

This avoids false-positive type errors like `LiveStore is not assignable to IndexedFormula` caused by two rdflib type origins.

## Jest stabilization for local linked repos
- Map `solid-logic` to source in Jest to avoid loading webpack bundle output during tests.
- Mock `@uvdsl/solid-oidc-client-browser` for Jest/JSDOM to avoid ESM/import.meta runtime issues.

## Integration outcome
- solid-ui now listens to the native session state change flow expected by the uvdsl client.
- Downstream packages can continue to function while solid-logic carries temporary compatibility shims.

## Suggested commit message

### Title
feat(auth): adopt uvdsl session contract in solid-ui and stabilize local linked dev

### Body
- Update solid-ui auth flow to uvdsl login/session contract
- Move session listeners to EventTarget sessionStateChange pattern
- Keep local linked-repo TypeScript settings to prevent duplicate rdflib type identity errors
- Add Jest mappings/mocks so tests run against source in local integrated workspace
- Document local integrated development rationale in README

## Suggested post-validation cleanup commit (optional)

### Title
refactor(auth): remove remaining transitional auth fallbacks in solid-ui

### Body
- Remove temporary fallback reads for legacy session shapes
- Keep only uvdsl-native state/event handling once integrated tests are stable
