### PR TITLE
#795 Fix staging CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - staging
   pull_request:
     branches:
       - main
+      - staging
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
+      - run: scripts/setup-ci.sh
       - run: npm test
       - run: npm run build
       - run: npm run doc

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"lint-fix": "eslint --fix",
 		"typecheck": "tsc --noEmit",
 		"typecheck-test": "tsc --noEmit -p tsconfig.test.json",
-		"test": "vitest run",
+		"test": "npm run typecheck-test && vitest run",
 		"test-coverage": "vitest run --coverage",
 		"test-debug": "vitest --inspect-brk --no-file-parallelism",
 		"doc": "typedoc --out ./docs/api/ ./src/ --excludeInternal",

--- a/scripts/setup-ci.sh
+++ b/scripts/setup-ci.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Clone, build, and link solid-logic for CI (peer dependency of solid-ui).
+# Run after `npm ci` so the local install is not removed.
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SOLID_LOGIC_DIR="${ROOT_DIR}/.ci-deps/solid-logic"
+SOLID_LOGIC_REPO="https://github.com/SolidOS/solid-logic.git"
+SOLID_LOGIC_REF="${GITHUB_BASE_REF:-${GITHUB_REF_NAME:-main}}"
+
+echo ">>>>> Setting up solid-logic from ${SOLID_LOGIC_REPO} (${SOLID_LOGIC_REF})"
+
+rm -rf "$SOLID_LOGIC_DIR"
+mkdir -p "$(dirname "$SOLID_LOGIC_DIR")"
+git clone --depth 1 --branch "$SOLID_LOGIC_REF" "$SOLID_LOGIC_REPO" "$SOLID_LOGIC_DIR"
+
+echo ">>>>> Installing solid-logic dependencies"
+(cd "$SOLID_LOGIC_DIR" && npm ci)
+
+echo ">>>>> Building solid-logic"
+(cd "$SOLID_LOGIC_DIR" && npm run build)
+
+echo ">>>>> Installing solid-logic as a local dependency in solid-ui"
+cd "$ROOT_DIR"
+npm install --no-save "solid-logic@file:${SOLID_LOGIC_DIR}"
+
+echo ">>>>> solid-logic setup complete"

--- a/test/unit/login/login.test.ts
+++ b/test/unit/login/login.test.ts
@@ -1,5 +1,4 @@
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest'
-import { authn, authSession, solidLogicSingleton } from 'solid-logic'
 import * as testLogin from '../../../src/login/login'
 
 describe('ensureLoggedIn', () => {
@@ -20,24 +19,25 @@ describe('getUserRoles', () => {
   })
 
   it('returns [] and does not load preferences when current user is missing', async () => {
-    vi.spyOn(authSession, 'info', 'get').mockReturnValue({
+    vi.resetModules()
+
+    const { authn, authSession, solidLogicSingleton } = await import('solid-logic')
+
+    authSession.info = {
       isLoggedIn: true,
-      webId: 'https://alice.example.com/profile/card#me',
-      sessionId: 'test-session'
-    })
+      webId: 'https://alice.example.com/profile/card#me'
+    }
 
-    const currentUserSpy = vi
-      .spyOn(authn, 'currentUser')
-      .mockReturnValue(null)
-    const loadPreferencesSpy = vi.spyOn(
-      solidLogicSingleton.profile,
-      'loadPreferences'
-    )
+    vi.spyOn(authn, 'checkUser').mockResolvedValue(null)
 
-    const roles = await testLogin.getUserRoles()
+    const currentUserSpy = vi.spyOn(authn, 'currentUser').mockReturnValue(null)
+    const loadPreferencesSpy = vi.spyOn(solidLogicSingleton.profile, 'loadPreferences')
 
-    expect(currentUserSpy).toHaveBeenCalled()
+    const { getUserRoles } = await import('../../../src/login/login')
+    const roles = await getUserRoles()
+
     expect(roles).toEqual([])
+    expect(currentUserSpy).toHaveBeenCalled()
     expect(loadPreferencesSpy).not.toHaveBeenCalled()
   })
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -66,6 +66,10 @@ function defaultConfig(): UserConfig {
         test: {
             environment: 'jsdom',
             setupFiles: ['test/helpers/setup.ts'],
+            include: [
+                'src/**/*.test.ts',
+                'test/**/*.test.ts',
+            ],
             coverage: {
                 include: ['src/**/*.[jt]s'],
             },


### PR DESCRIPTION
This PR fixes the issues we have in CI as described in #795.

The fix clones the `solid-logic` dependency, and installs it locally before running the rest of the CI. This only works with `solid-logic` now, but this script could be refactored to take a list of dependencies that should be symlinked this way. Also, we could potentially use the same script in other repositories in the organization in order to run their respective CIs.

Overall, this is a working solution but it isn't ideal. Even though the CI works, developers will still need to manage their own local dependencies. Maybe this isn't too much of a problem, given that the expected development workflow is to use the Lerna config from the `solidos` repository.

If we want to improve this in the future, I can only think of two solutions:

- Release development versions of the libraries (some people have raised concerns about this approach in https://github.com/SolidOS/mashlib/issues/317).
- Migrate everything to a monorepo (would be nice, but it's obviously a lot of work).