### PR TITLE
Fix auth test

### DIFF
--- a/test/unit/login/login.test.ts
+++ b/test/unit/login/login.test.ts
@@ -20,11 +20,11 @@ describe('getUserRoles', () => {
   })
 
   it('returns [] and does not load preferences when current user is missing', async () => {
-    vi.spyOn(authSession, 'info', 'get').mockReturnValue({
+    authSession.info = {
       isLoggedIn: true,
       webId: 'https://alice.example.com/profile/card#me',
       sessionId: 'test-session'
-    })
+    }
 
     const currentUserSpy = vi
       .spyOn(authn, 'currentUser')


### PR DESCRIPTION
Why this fails
`vi.spyOn(authSession, 'info', 'get') i`s not defined as a getter property on that object.

`vi.spyOn(obj, prop, 'get' `requires prop to be an accessor with a getter descriptor.
In solid-logic is a plain property on the session object, not a getter.
So Vitest throws: `[The property "info" is not defined on the object.]`

Find fix I chose in this PR.