### PR TITLE
fix preference error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7280,9 +7280,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.385",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
-			"integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
+			"version": "1.5.387",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
+			"integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -11023,9 +11023,9 @@
 			"license": "MIT"
 		},
 		"node_modules/n3": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/n3/-/n3-2.1.0.tgz",
-			"integrity": "sha512-+05H/h40wRyROglcVGrNZAwBu0Nc87luKhiTV95aGBGX1YyITtpwftHwyhT5YoZr4soXJWrzxqC1CHPdGqV63g==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/n3/-/n3-2.1.1.tgz",
+			"integrity": "sha512-kqg8ers6Lc+uAmHeS+ycd3b8mC4x8wr8V8Fi6+w7l4hX6b0KZ5bT05Tf49qM2mujwaqZT3+08zcgtXgfxivbVQ==",
 			"license": "MIT",
 			"dependencies": {
 				"buffer": "^6.0.3",

--- a/src/lib/preferences.js
+++ b/src/lib/preferences.js
@@ -69,6 +69,10 @@ export function recordSharedPreferences (subject, context) {
 //
 export function recordPersonalDefaults (theClass, context) {
   return new Promise(function (resolve, reject) {
+    if (!context.me) {
+      resolve(context)
+      return
+    }
     ensureLoadedPreferences(context).then(
       context => {
         if (!context.preferencesFile) {

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -1053,7 +1053,11 @@ export function newAppInstance (
  */
 export async function getUserRoles (): Promise<Array<NamedNode>> {
   try {
-    const { me, preferencesFile, preferencesFileError } = await ensureLoadedPreferences({})
+    const me = authn.currentUser()
+    if (!me) {
+      return []
+    }
+    const { preferencesFile, preferencesFileError } = await ensureLoadedPreferences({})
     if (!preferencesFile || preferencesFileError) {
       throw new Error(preferencesFileError)
     }

--- a/test/unit/preferences.test.ts
+++ b/test/unit/preferences.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { silenceDebugMessages } from './helpers/debugger'
 import { JSDOM } from 'jsdom'
+vi.mock('../../src/login/login', () => ({
+  ensureLoadedPreferences: vi.fn()
+}))
+
+import * as loginModule from '../../src/login/login'
 import * as Preferences from '../../src/lib/preferences'
 import { sym } from 'rdflib'
 
@@ -61,6 +66,18 @@ describe('Preferences.recordSharedPreferences', () => {
     const subject = sym('https://test.test/sub')
     const context = {}
     expect(Preferences.recordSharedPreferences(subject, context)).toBeTruthy()
+  })
+})
+
+describe('Preferences.recordPersonalDefaults', () => {
+  it('does not try to load preferences when there is no logged-in user', async () => {
+    const ensureLoadedPreferencesMock = vi.mocked(loginModule.ensureLoadedPreferences)
+
+    const context = { me: null }
+    const result = await Preferences.recordPersonalDefaults('https://test.example/class', context)
+
+    expect(result).toBe(context)
+    expect(ensureLoadedPreferencesMock).not.toHaveBeenCalled()
   })
 })
 

--- a/test/unit/preferences.test.ts
+++ b/test/unit/preferences.test.ts
@@ -74,8 +74,7 @@ describe('Preferences.recordPersonalDefaults', () => {
     const ensureLoadedPreferencesMock = vi.mocked(loginModule.ensureLoadedPreferences)
 
     const context = { me: null }
-    const result = await Preferences.recordPersonalDefaults('https://test.example/class', context)
-
+    const result = await Preferences.recordPersonalDefaults(sym('https://test.example/class'), context)
     expect(result).toBe(context)
     expect(ensureLoadedPreferencesMock).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
Another attempt to fix the preference error.

When logging out there were 2 user preferences errors when we shouldn't need to load preferences anyway when logging out.

when logging in there was one error, it shouldn't try to retrieve them until the user log in details are stored.