### PR TITLE
Add theme options for code editor

### DIFF
--- a/src/lib/code-editor/CodeEditor.styles.css
+++ b/src/lib/code-editor/CodeEditor.styles.css
@@ -1,0 +1,52 @@
+.code-editor-shell {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	width: 100%;
+	min-width: 0;
+}
+
+.code-editor-toolbar {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+	width: 100%;
+	min-width: 0;
+}
+
+.code-editor-toolbar-label {
+	font-size: 0.875rem;
+	font-weight: 600;
+	opacity: 0.8;
+}
+
+.code-editor-theme-button {
+	border: 1px solid currentColor;
+	border-radius: 999px;
+	padding: 0.25rem 0.75rem;
+	cursor: pointer;
+	font: inherit;
+	background: transparent;
+}
+
+.code-editor-theme-button[data-active='true'] {
+	background-color: #111827;
+	color: #ffffff;
+}
+
+.code-editor-editor-host {
+	width: 100%;
+	min-width: 0;
+}
+
+.code-editor-editor-host .cm-editor {
+	min-height: 6lh;
+	font-size: 16px;
+}
+
+.code-editor-editor-host .cm-content,
+.code-editor-editor-host .cm-gutters {
+	font-size: 16px;
+}

--- a/src/lib/code-editor/CodeEditor.ts
+++ b/src/lib/code-editor/CodeEditor.ts
@@ -9,17 +9,23 @@ import { javascript } from '@codemirror/lang-javascript'
 import { json } from '@codemirror/lang-json'
 import { markdown } from '@codemirror/lang-markdown'
 import { xml } from '@codemirror/lang-xml'
+import { html as litHtml, render } from 'lit'
 import { vscodeDark, vscodeLight } from '@uiw/codemirror-theme-vscode'
 import { turtle } from '@codemirror/legacy-modes/mode/turtle'
 import { sparql } from '@codemirror/legacy-modes/mode/sparql'
 import { ntriples } from '@codemirror/legacy-modes/mode/ntriples'
+import styles from './CodeEditor.styles.css'
 
 export class CodeEditor {
   private _view: EditorView | null = null
   private _languageCompartment: Compartment | null = null
   private _editableCompartment: Compartment | null = null
+  private _themeCompartment: Compartment | null = null
   private _onDirtyChange?: (dirty: boolean) => void
   private _isDirty = false
+  private _themeMode: ThemeMode = 'dark'
+  private _root: HTMLDivElement | null = null
+  private _styleElement: HTMLStyleElement | null = null
 
   async initialize (container: HTMLElement, initialDoc = '', contentType: string = 'text/turtle', theme: ThemeMode = 'dark', onDirtyChange?: (dirty: boolean) => void) {
     if (this._view) {
@@ -28,19 +34,25 @@ export class CodeEditor {
 
     this._languageCompartment = new Compartment()
     this._editableCompartment = new Compartment()
+    this._themeCompartment = new Compartment()
     this._onDirtyChange = onDirtyChange
     this._isDirty = false
+    this._themeMode = theme
+
+    render(this._renderTemplate(), container)
+    this._root = container.firstElementChild as HTMLDivElement | null
+    this._attachStyles(container)
+    const editorHost = container.querySelector('.code-editor-editor-host') as HTMLDivElement | null
+    if (!editorHost) {
+      throw new Error('Code editor host was not rendered.')
+    }
+
     const languageExtension = await this._getLanguageExtension(contentType)
 
     const state = EditorState.create({
       doc: initialDoc,
       extensions: [
-        theme === 'dark' ? vscodeDark : vscodeLight,
-        EditorView.theme({
-          '&': {
-            minHeight: '6lh'
-          }
-        }),
+        this._themeCompartment.of(this._getThemeExtension(theme)),
         this._languageCompartment.of(languageExtension),
         this._editableCompartment.of(EditorView.editable.of(true)),
         syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
@@ -63,13 +75,20 @@ export class CodeEditor {
 
     this._view = new EditorView({
       state,
-      parent: container
+      parent: editorHost
     })
   }
 
   destroy () {
     this._view?.destroy()
     this._view = null
+    this._styleElement?.remove()
+    this._styleElement = null
+    if (this._root?.parentNode) {
+      this._root.parentNode.removeChild(this._root)
+    }
+    this._root = null
+    this._themeCompartment = null
     this._isDirty = false
   }
 
@@ -88,6 +107,19 @@ export class CodeEditor {
 
   resetDirtyState () {
     this._isDirty = false
+  }
+
+  setThemeMode (theme: ThemeMode) {
+    this._themeMode = theme
+    this._updateThemeButtonState()
+
+    if (!this._view) return
+    const themeCompartment = this._themeCompartment
+    if (!themeCompartment) return
+
+    this._view.dispatch({
+      effects: themeCompartment.reconfigure(this._getThemeExtension(theme))
+    })
   }
 
   setReadOnly (readOnly: boolean) {
@@ -157,5 +189,69 @@ export class CodeEditor {
       default:
         return []
     }
+  }
+
+  private _getThemeExtension (theme: ThemeMode) {
+    return theme === 'dark' ? vscodeDark : vscodeLight
+  }
+
+  private _renderTemplate () {
+    return litHtml`
+      <div class="code-editor-shell">
+        <div class="code-editor-toolbar">
+          <span class="code-editor-toolbar-label">Theme</span>
+          <button
+            type="button"
+            class="code-editor-theme-button"
+            data-theme="dark"
+            title="Use dark editor theme"
+            data-active=${String(this._themeMode === 'dark')}
+            aria-pressed=${String(this._themeMode === 'dark')}
+            @click=${() => this.setThemeMode('dark')}
+          >
+            Dark
+          </button>
+          <button
+            type="button"
+            class="code-editor-theme-button"
+            data-theme="light"
+            title="Use light editor theme"
+            data-active=${String(this._themeMode !== 'dark')}
+            aria-pressed=${String(this._themeMode !== 'dark')}
+            @click=${() => this.setThemeMode('light')}
+          >
+            Light
+          </button>
+        </div>
+        <div class="code-editor-editor-host"></div>
+      </div>
+    `
+  }
+
+  private _updateThemeButtonState () {
+    if (!this._root) return
+    const darkButton = this._root.querySelector('.code-editor-theme-button[data-theme="dark"]') as HTMLButtonElement | null
+    const lightButton = this._root.querySelector('.code-editor-theme-button[data-theme="light"]') as HTMLButtonElement | null
+    this._syncThemeButton(darkButton, this._themeMode === 'dark')
+    this._syncThemeButton(lightButton, this._themeMode !== 'dark')
+  }
+
+  private _syncThemeButton (button: HTMLButtonElement | null, isActive: boolean) {
+    if (!button) return
+    button.setAttribute('aria-pressed', String(isActive))
+    button.dataset.active = String(isActive)
+  }
+
+  private _attachStyles (container: HTMLElement) {
+    this._styleElement?.remove()
+
+    const styleText = typeof styles === 'string'
+      ? styles
+      : (styles as { cssText?: string }).cssText ?? ''
+
+    const styleElement = container.ownerDocument.createElement('style')
+    styleElement.textContent = styleText
+    container.append(styleElement)
+    this._styleElement = styleElement
   }
 }

--- a/test/unit/codeEditor.test.js
+++ b/test/unit/codeEditor.test.js
@@ -142,7 +142,10 @@ describe('CodeEditor', () => {
     expect(editor.getValue()).toBe('hello world')
     expect(createdViews).toHaveLength(1)
     expect(createdViews[0].state.doc).toBe('hello world')
-    expect(createdViews[0].parent).toBe(container)
+    expect(container.firstElementChild?.classList.contains('code-editor-shell')).toBe(true)
+    expect(container.querySelector('.code-editor-toolbar')).not.toBeNull()
+    expect(container.querySelector('.code-editor-editor-host')).not.toBeNull()
+    expect(createdViews[0].parent).toBe(container.querySelector('.code-editor-editor-host'))
   })
 
   it('replaces content and toggles read only state', async () => {
@@ -186,5 +189,22 @@ describe('CodeEditor', () => {
 
     expect(onDirtyChange).toHaveBeenCalledTimes(1)
     expect(onDirtyChange).toHaveBeenCalledWith(true)
+  })
+
+  it('toggles the editor theme from the toolbar', async () => {
+    const editor = new CodeEditor()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    await editor.initialize(container, 'first', 'text/plain', 'dark')
+    const view = createdViews[0]
+    const lightButton = container.querySelector('button[title="Use light editor theme"]')
+
+    expect(lightButton).not.toBeNull()
+    lightButton?.dispatchEvent(new window.MouseEvent('click', { bubbles: true }))
+
+    expect(view.dispatch).toHaveBeenCalled()
+    const lastCall = view.dispatch.mock.calls.at(-1)?.[0]
+    expect(lastCall.effects.value[0].type).toBe('lightTheme')
   })
 })


### PR DESCRIPTION
This PR is against another PR where I moved the code editor to solid-ui (not staging yet). @bourgeoa you mentioned not loving the dark theme so I thought I'd just have a quick go at seeing what our options were for allowing users to change it inside the editor so we don't have to store their preferences (since this would mean deciding on a predicate etc and may take longer to implement)

Here is how it looks, but we could easily change the look this is just a rough draft. I created this for discussion. 
Note: the light theme can be changed as well there are many different extensions we could pick from, if we did do this and chose this one i'd put some sort of border around the code.

<img width="1131" height="315" alt="Screenshot 2026-08-06 at 11 14 54 AM" src="https://github.com/user-attachments/assets/a329c12f-f844-448f-81be-715e4a2d53b9" />

<img width="1129" height="334" alt="Screenshot 2026-08-06 at 11 22 19 AM" src="https://github.com/user-attachments/assets/4d75459a-454f-4cfb-a1b6-5910cfc84bc3" />

