### PR TITLE
Update context.me

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3166,9 +3166,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@iconify/utils": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.5.tgz",
-			"integrity": "sha512-nT+AWyh5caHY6xa0PdLXpUooIz6l7qsT+adqsCTYBfbdn5Q18VrWs2fvuTa7KEoJnPBfEPqWkmAIht0EHtCi2A==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.7.tgz",
+			"integrity": "sha512-JZHlwdID+dy+lTgbYC8NEC4zeugqeYsc6jewvzb4c58kHauJn+X7rNwQjxz5p2qSjqaEeQoLkCIQ9v/H4PK0/w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4522,13 +4522,13 @@
 			}
 		},
 		"node_modules/@rolldown/plugin-babel": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/plugin-babel/-/plugin-babel-0.2.3.tgz",
-			"integrity": "sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==",
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/plugin-babel/-/plugin-babel-0.2.4.tgz",
+			"integrity": "sha512-ygmm2j/mN+aCvstHo0x3IOu4uc6LqXT9SJ3q4kpfG/+Yhfz0B+E47FITcC0FljZADwUFARP6E2kiE+Lc26D8wg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"picomatch": "^4.0.4"
+				"picomatch": "^4.0.7"
 			},
 			"engines": {
 				"node": ">=22.12.0 || ^24.0.0"
@@ -5290,9 +5290,9 @@
 			}
 		},
 		"node_modules/@types/jsdom/node_modules/entities": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.1.0.tgz",
+			"integrity": "sha512-kxL7msIffSuh9aaFAMD7rxAIuTRMAHMeBtgHW2yUdWw732ZNh4MehkF2gdjvtdmikkaIP9bFDDJOPlsvm7avrA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
@@ -5382,17 +5382,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.69.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.69.0.tgz",
-			"integrity": "sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==",
+			"version": "8.70.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.70.0.tgz",
+			"integrity": "sha512-/v8HZt6RlyIZxB3ntehELOcUcfxKPVGWXnQdJuHRmzrqgF8nQypcC/oxGW+Ot4VGKDq81XugPKxx0n5PBtf9PA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.69.0",
-				"@typescript-eslint/type-utils": "8.69.0",
-				"@typescript-eslint/utils": "8.69.0",
-				"@typescript-eslint/visitor-keys": "8.69.0",
+				"@typescript-eslint/scope-manager": "8.70.0",
+				"@typescript-eslint/type-utils": "8.70.0",
+				"@typescript-eslint/utils": "8.70.0",
+				"@typescript-eslint/visitor-keys": "8.70.0",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -5405,7 +5405,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.69.0",
+				"@typescript-eslint/parser": "^8.70.0",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
@@ -5421,16 +5421,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.69.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.69.0.tgz",
-			"integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
+			"version": "8.70.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.70.0.tgz",
+			"integrity": "sha512-zYvrmj9Yxd63UGaXw+kdt6A0F0s0qveJyuatIM77bYC2DE4pgmg7a50u8LR7PRtXd0x+h+Tl3eXabGm06SWd3Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.69.0",
-				"@typescript-eslint/types": "8.69.0",
-				"@typescript-eslint/typescript-estree": "8.69.0",
-				"@typescript-eslint/visitor-keys": "8.69.0",
+				"@typescript-eslint/scope-manager": "8.70.0",
+				"@typescript-eslint/types": "8.70.0",
+				"@typescript-eslint/typescript-estree": "8.70.0",
+				"@typescript-eslint/visitor-keys": "8.70.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -5446,14 +5446,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.69.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
-			"integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
+			"version": "8.70.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.70.0.tgz",
+			"integrity": "sha512-hFHbTNqhU9G+2eKFXCBVb1tjFT/LceiJ4+HfLO4pTpDI0KHi6iajpcFFkaSQ9gXmCh7n82A0PthaayEdN6mspQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.69.0",
-				"@typescript-eslint/types": "^8.69.0",
+				"@typescript-eslint/tsconfig-utils": "^8.70.0",
+				"@typescript-eslint/types": "^8.70.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -5468,14 +5468,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.69.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
-			"integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
+			"version": "8.70.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.70.0.tgz",
+			"integrity": "sha512-8nP3Kwh5hlgZ4FicGvmznAmJe8UL4sdU8tLukrPaMuQmDuk4Y8xYfzu/aYZW4xT2JCgc7H/TpDI5cGlxcWJSqQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.69.0",
-				"@typescript-eslint/visitor-keys": "8.69.0"
+				"@typescript-eslint/types": "8.70.0",
+				"@typescript-eslint/visitor-keys": "8.70.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5486,9 +5486,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.69.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
-			"integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
+			"version": "8.70.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.70.0.tgz",
+			"integrity": "sha512-adnkeeNq9Sq1sUf4+FRVc0KdgYghzsgFpZSQVZVvY0LCuUuN0FnQgyGzCJeC4fW1cdXseBAjU2EOqUIjbNcZUw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5503,15 +5503,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.69.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.69.0.tgz",
-			"integrity": "sha512-ZfoJAVg3JZndQEpEl9petVlxau3lRuElc4HRMuAlLCf8to04/iHz692RUSNmXKDjEuJmIL+KZ2/BsOcBc16dsA==",
+			"version": "8.70.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.70.0.tgz",
+			"integrity": "sha512-NUMKIhYVaVIVLnRL9CRt+VVcuLgSHUCpXn4/+K8wql+vdInUzvx8BjUO1oJ7cG9shjFJKtF8F8Hh2kCh3/KBVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.69.0",
-				"@typescript-eslint/typescript-estree": "8.69.0",
-				"@typescript-eslint/utils": "8.69.0",
+				"@typescript-eslint/types": "8.70.0",
+				"@typescript-eslint/typescript-estree": "8.70.0",
+				"@typescript-eslint/utils": "8.70.0",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -5528,9 +5528,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.69.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
-			"integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
+			"version": "8.70.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.70.0.tgz",
+			"integrity": "sha512-asTOIYhDg4zdzOScCyaytrsV3cR6B4ecPQlXw/dJIm7J/MZTtCtfVII9JD8Geh4jTCrK/Xe6cg5UevoleMcoJQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5542,16 +5542,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.69.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
-			"integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
+			"version": "8.70.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.70.0.tgz",
+			"integrity": "sha512-d9NmHMPEKQ7QCLLm1jI3zmoQBwT5KwFYjXBJ9ymZfKCUU+5rmTRykKAFvH5Qn/ZCds3CEAFS9OC9M/jkl0X2bA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.69.0",
-				"@typescript-eslint/tsconfig-utils": "8.69.0",
-				"@typescript-eslint/types": "8.69.0",
-				"@typescript-eslint/visitor-keys": "8.69.0",
+				"@typescript-eslint/project-service": "8.70.0",
+				"@typescript-eslint/tsconfig-utils": "8.70.0",
+				"@typescript-eslint/types": "8.70.0",
+				"@typescript-eslint/visitor-keys": "8.70.0",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -5583,16 +5583,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.69.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
-			"integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
+			"version": "8.70.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.70.0.tgz",
+			"integrity": "sha512-oZmtKJz/4fufZ2p3+Cn3ijEojcdfR+1zYDH2xKYrEly0dR/Q/1xUPRCOlKGxod78nWlU2UnDe09GZ3TaknBFGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.69.0",
-				"@typescript-eslint/types": "8.69.0",
-				"@typescript-eslint/typescript-estree": "8.69.0"
+				"@typescript-eslint/scope-manager": "8.70.0",
+				"@typescript-eslint/types": "8.70.0",
+				"@typescript-eslint/typescript-estree": "8.70.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5607,13 +5607,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.69.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
-			"integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
+			"version": "8.70.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.70.0.tgz",
+			"integrity": "sha512-BoC8PiO4Hkdo0TVJh9Ntxr5MxPDI7/oFsrygN5ADelFSeXG/qgNuucIGA+L5Z6JpPTE/uRfcTWtscjbUaufepQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/types": "8.70.0",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -6593,9 +6593,9 @@
 			}
 		},
 		"node_modules/ast-v8-to-istanbul": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
-			"integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.6.tgz",
+			"integrity": "sha512-fvpl29helSO2w/z7utIbrkNXILdrLwDwAMH2I/zPKlGf5244+gf+B4cyS1sANcrPY2h+hWCGSgC8N61s/+AF9A==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6723,9 +6723,9 @@
 			}
 		},
 		"node_modules/bidi-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.1.0.tgz",
+			"integrity": "sha512-fX1Onk0tdVPC7obPWB5EbJ1z7NVhLq4m2xZLq2YXBkxzMXIGRpNMU88n0EPgWseKl12J7zXs7qrDxPK4sRs2fg==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10461,9 +10461,9 @@
 			}
 		},
 		"node_modules/jsdom/node_modules/entities": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.1.0.tgz",
+			"integrity": "sha512-kxL7msIffSuh9aaFAMD7rxAIuTRMAHMeBtgHW2yUdWw732ZNh4MehkF2gdjvtdmikkaIP9bFDDJOPlsvm7avrA==",
 			"devOptional": true,
 			"license": "BSD-2-Clause",
 			"engines": {
@@ -11371,9 +11371,9 @@
 			"license": "MIT"
 		},
 		"node_modules/n3": {
-			"version": "2.7.6",
-			"resolved": "https://registry.npmjs.org/n3/-/n3-2.7.6.tgz",
-			"integrity": "sha512-0jKTv1PEhDRFkwv+5RD4VpTN3Ub55xEINWYXqhBZ82MJsgqVXZcAPHOuA9pwxZ0vvf5h6TOruOQG3Wj9HzDbWw==",
+			"version": "2.7.12",
+			"resolved": "https://registry.npmjs.org/n3/-/n3-2.7.12.tgz",
+			"integrity": "sha512-Hy6dfGg9yniLQpSBirvH2E2yO3EG7dSmA3aefRbtO411oqtzG8roD3h1kTc/N065bivCOPfTFIjf0KlwW7KlnQ==",
 			"license": "MIT",
 			"dependencies": {
 				"buffer": "^6.0.3",
@@ -12395,13 +12395,13 @@
 			}
 		},
 		"node_modules/pkg-types": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.2.tgz",
-			"integrity": "sha512-v0sVXzj7oPGysr543YYZLYbcJNJsKikSsp/fFzoxQ12ewY3ZZr7oCPC8y7OlmxfYB3QPvriXmuPD8KZggE1vqg==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.3.tgz",
+			"integrity": "sha512-j/lCFdcppV0JxWpCEITdbDltBxPP6cHT+yNJ6Go2OgoSA9518X847X9z0p6LtA4Nc16+eQzCZjRrWanTGvHJ5w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"confbox": "^0.3.0",
+				"confbox": "^0.3.1",
 				"exsolve": "^1.1.1",
 				"pathe": "^2.0.3"
 			}
@@ -13929,22 +13929,22 @@
 			}
 		},
 		"node_modules/tldts": {
-			"version": "7.4.11",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
-			"integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+			"version": "7.4.12",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.12.tgz",
+			"integrity": "sha512-WylhSDKVeYnWXL3a+vKTaOxjnOeEGw938hImY8zoRWJjRRK/Jp1K+IihBzIONpUmW4e3WmXT6q5FW6vlESVZCA==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^7.4.11"
+				"tldts-core": "^7.4.12"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "7.4.11",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
-			"integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+			"version": "7.4.12",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.12.tgz",
+			"integrity": "sha512-nYNzS2WRf4QJmjzFFgAxLOBjyBxAGRbCy9PVBPaglcYyYajh40VBn+v5Ngr96ZMc7oM0+aCJdtQnNejvdBnXMQ==",
 			"devOptional": true,
 			"license": "MIT"
 		},
@@ -14216,16 +14216,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.69.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz",
-			"integrity": "sha512-B3MltX0VqjUBNEe3b3sSuiRbfa6XrfHFtBiPamjT5AsW/dfq+y+bc0wyuS9DxAS1LyzCxRp2+rxzpLUvqM2BvA==",
+			"version": "8.70.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.70.0.tgz",
+			"integrity": "sha512-P/W5cz70/cQAuKfY3xwQMWWTV7BvJ0mAQmi+9mBcsVPaBUpd6Ohpa+fECv9rBFrQcig86jAiNBFNWUqnTjr4pw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.69.0",
-				"@typescript-eslint/parser": "8.69.0",
-				"@typescript-eslint/typescript-estree": "8.69.0",
-				"@typescript-eslint/utils": "8.69.0"
+				"@typescript-eslint/eslint-plugin": "8.70.0",
+				"@typescript-eslint/parser": "8.70.0",
+				"@typescript-eslint/typescript-estree": "8.70.0",
+				"@typescript-eslint/utils": "8.70.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/src/login/login.ts
+++ b/src/login/login.ts
@@ -83,6 +83,7 @@ export function ensureLoggedIn (context: AuthenticationContext): Promise<Authent
       // Already logged in?
       if (webId) {
         debug.log(`logIn: Already logged in as ${webId}`)
+        authn.saveUser(webId as any, context)
         return resolve(context)
       }
       if (!context.div || !context.dom) {
@@ -198,10 +199,14 @@ export async function ensureLoadedProfile (
   } // already done
   try {
     const logInContext = await ensureLoggedIn(context)
-    if (!logInContext.me) {
+    const resolvedMe = logInContext.me || authn.currentUser()
+    if (!resolvedMe) {
       throw new Error('Could not log in')
     }
-    context.publicProfile = await loadProfile(logInContext.me)
+    if (!logInContext.me) {
+      authn.saveUser(resolvedMe as any, context)
+    }
+    context.publicProfile = await loadProfile(resolvedMe)
   } catch (err) {
     if (context.div && context.dom) {
       context.div.appendChild(widgets.errorMessageBlock(context.dom, err.message))

--- a/test/unit/login/login.test.ts
+++ b/test/unit/login/login.test.ts
@@ -11,6 +11,23 @@ describe('ensureLoggedIn', () => {
   it('runs', () => {
     expect(testLogin.ensureLoggedIn({})).toBeInstanceOf(Object)
   })
+  it('saves the resolved webId into context when checkUser returns a webId', async () => {
+    const { authn } = await import('solid-logic')
+    const context: any = {}
+    const resolvedWebId = 'https://alice.example.com/profile/card#me'
+
+    const currentUserSpy = vi.spyOn(authn, 'currentUser').mockReturnValue(null)
+    const checkUserSpy = vi.spyOn(authn, 'checkUser').mockResolvedValue(resolvedWebId as any)
+    const saveUserSpy = vi.spyOn(authn, 'saveUser')
+
+    const resultPromise = testLogin.ensureLoggedIn(context)
+
+    await expect(resultPromise).resolves.toBe(context)
+    expect(currentUserSpy).toHaveBeenCalled()
+    expect(checkUserSpy).toHaveBeenCalled()
+    expect(saveUserSpy).toHaveBeenCalledWith(resolvedWebId, context)
+    expect(context.me?.uri).toBe(resolvedWebId)
+  })
 })
 
 describe('getUserRoles', () => {


### PR DESCRIPTION
When researching an issue we are having with PATCH on the profile card resource, creating lots of logs led to exposing the following small bug.

Note: this did not fix the PATCH issue.

The logs showed the login flow actually entering ensureLoggedIn() and then ensureLoadedProfile(), and they exposed a race where authn.currentUser() was already available but context.me was still empty. So I have added a saveuser call to refresh the context.